### PR TITLE
Switched to HyperModel v0.2.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -8,16 +8,15 @@ python-versions = "*"
 
 [[package]]
 name = "astroid"
-version = "2.4.2"
+version = "2.5"
 description = "An abstract syntax tree for Python with inference support."
 category = "dev"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [package.dependencies]
-lazy-object-proxy = ">=1.4.0,<1.5.0"
-six = ">=1.12,<2.0"
-wrapt = ">=1.11,<2.0"
+lazy-object-proxy = ">=1.4.0"
+wrapt = ">=1.11,<1.13"
 
 [[package]]
 name = "atomicwrites"
@@ -149,7 +148,7 @@ test = ["pytest (==5.4.3)", "pytest-cov (==2.10.0)", "pytest-asyncio (>=0.14.0,<
 
 [[package]]
 name = "fastapi-hypermodel"
-version = "0.1.0"
+version = "0.2.0"
 description = "A FastAPI + Pydantic extension for simplifying hypermedia-driven API development."
 category = "main"
 optional = false
@@ -176,10 +175,10 @@ typing-extensions = ">=3.7.4,<4.0.0"
 
 [package.extras]
 gino = ["gino[starlette] (>=1.0.1,<2.0.0)", "SQLAlchemy (>=1.3.20,<2.0.0)", "sqlalchemy-stubs (>=0.3,<0.4)"]
-all = ["gino[starlette] (>=1.0.1,<2.0.0)", "SQLAlchemy (>=1.3.20,<2.0.0)", "sqlalchemy-stubs (>=0.3,<0.4)", "databases[sqlite,postgresql,mysql] (>=0.4.0,<0.5.0)", "orm (>=0.1.5,<0.2.0)", "tortoise-orm[aiomysql,aiosqlite,asyncpg] (>=0.16.18,<0.17.0)"]
+all = ["gino[starlette] (>=1.0.1,<2.0.0)", "SQLAlchemy (>=1.3.20,<2.0.0)", "sqlalchemy-stubs (>=0.3,<0.4)", "databases[sqlite,mysql,postgresql] (>=0.4.0,<0.5.0)", "orm (>=0.1.5,<0.2.0)", "tortoise-orm[aiomysql,aiosqlite,asyncpg] (>=0.16.18,<0.17.0)"]
 sqlalchemy = ["SQLAlchemy (>=1.3.20,<2.0.0)", "sqlalchemy-stubs (>=0.3,<0.4)"]
-databases = ["databases[sqlite,postgresql,mysql] (>=0.4.0,<0.5.0)"]
-orm = ["databases[sqlite,postgresql,mysql] (>=0.4.0,<0.5.0)", "orm (>=0.1.5,<0.2.0)"]
+databases = ["databases[sqlite,mysql,postgresql] (>=0.4.0,<0.5.0)"]
+orm = ["databases[sqlite,mysql,postgresql] (>=0.4.0,<0.5.0)", "orm (>=0.1.5,<0.2.0)"]
 tortoise = ["tortoise-orm[aiomysql,aiosqlite,asyncpg] (>=0.16.18,<0.17.0)"]
 
 [[package]]
@@ -243,11 +242,11 @@ colors = ["colorama (>=0.4.3,<0.5.0)"]
 
 [[package]]
 name = "lazy-object-proxy"
-version = "1.4.3"
+version = "1.5.2"
 description = "A fast and thorough lazy object proxy."
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "mccabe"
@@ -361,18 +360,21 @@ typing_extensions = ["typing-extensions (>=3.7.2)"]
 
 [[package]]
 name = "pylint"
-version = "2.6.2"
+version = "2.7.1"
 description = "python code static checker"
 category = "dev"
 optional = false
-python-versions = ">=3.5.*"
+python-versions = "~=3.6"
 
 [package.dependencies]
-astroid = ">=2.4.0,<2.5"
+astroid = "2.5.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 isort = ">=4.2.5,<6"
 mccabe = ">=0.6,<0.7"
 toml = ">=0.7.1"
+
+[package.extras]
+docs = ["sphinx (>=3.2,<4.0)", "python-docs-theme"]
 
 [[package]]
 name = "pyparsing"
@@ -595,7 +597,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "uvicorn"
-version = "0.13.3"
+version = "0.13.4"
 description = "The lightning-fast ASGI server."
 category = "main"
 optional = false
@@ -606,7 +608,7 @@ click = ">=7.0.0,<8.0.0"
 h11 = ">=0.8"
 
 [package.extras]
-standard = ["websockets (>=8.0.0,<9.0.0)", "watchgod (>=0.6,<0.7)", "python-dotenv (>=0.13)", "PyYAML (>=5.1)", "httptools (>=0.1.0,<0.2.0)", "uvloop (>=0.14.0)", "colorama (>=0.4)"]
+standard = ["websockets (>=8.0.0,<9.0.0)", "watchgod (>=0.6)", "python-dotenv (>=0.13)", "PyYAML (>=5.1)", "httptools (>=0.1.0,<0.2.0)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "colorama (>=0.4)"]
 
 [[package]]
 name = "virtualenv"
@@ -645,7 +647,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8" 
-content-hash = "4df3e34a70330054baca6314da4cd2b53c8bcb4af40440fdcb65c4e3c41a1101"
+content-hash = "95e555c931b832e95ecb89d691b9c307300f43bbaa99a6b2c7dfca64aae7d196"
 
 [metadata.files]
 appdirs = [
@@ -653,8 +655,8 @@ appdirs = [
     {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
 ]
 astroid = [
-    {file = "astroid-2.4.2-py3-none-any.whl", hash = "sha256:bc58d83eb610252fd8de6363e39d4f1d0619c894b0ed24603b881c02e64c7386"},
-    {file = "astroid-2.4.2.tar.gz", hash = "sha256:2f4078c2a41bf377eea06d71c9d2ba4eb8f6b1af2135bec27bbbb7d8f12bb703"},
+    {file = "astroid-2.5-py3-none-any.whl", hash = "sha256:87ae7f2398b8a0ae5638ddecf9987f081b756e0e9fc071aeebdca525671fc4dc"},
+    {file = "astroid-2.5.tar.gz", hash = "sha256:b31c92f545517dcc452f284bc9c044050862fbe6d93d2b3de4a215a6b384bf0d"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -747,8 +749,8 @@ fastapi = [
     {file = "fastapi-0.63.0.tar.gz", hash = "sha256:63c4592f5ef3edf30afa9a44fa7c6b7ccb20e0d3f68cd9eba07b44d552058dcb"},
 ]
 fastapi-hypermodel = [
-    {file = "fastapi-hypermodel-0.1.0.tar.gz", hash = "sha256:fc46059799ce4e5e61f6edeb4304738808ded06a740402a8ee852fcb4a141d4f"},
-    {file = "fastapi_hypermodel-0.1.0-py3-none-any.whl", hash = "sha256:5f7ec76855c1b9cdc1addef033aa79ca7e92d1002efd92e5b84b7cd5054bb78f"},
+    {file = "fastapi-hypermodel-0.2.0.tar.gz", hash = "sha256:42a5a2c506da53651fa7f33911800824846c00df24ec5647bbd2cdf248d3cf26"},
+    {file = "fastapi_hypermodel-0.2.0-py3-none-any.whl", hash = "sha256:a10c9c7271c901f20240afaa3ae4524d8eaae5155403881412f21356146e52d8"},
 ]
 fastapi-pagination = [
     {file = "fastapi-pagination-0.5.2.tar.gz", hash = "sha256:089574b30910ef3be40c96307fe26bdea71425f55af59c89cf866561cbbd4568"},
@@ -779,27 +781,30 @@ isort = [
     {file = "isort-5.7.0.tar.gz", hash = "sha256:c729845434366216d320e936b8ad6f9d681aab72dc7cbc2d51bedc3582f3ad1e"},
 ]
 lazy-object-proxy = [
-    {file = "lazy-object-proxy-1.4.3.tar.gz", hash = "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"},
-    {file = "lazy_object_proxy-1.4.3-cp27-cp27m-macosx_10_13_x86_64.whl", hash = "sha256:a2238e9d1bb71a56cd710611a1614d1194dc10a175c1e08d75e1a7bcc250d442"},
-    {file = "lazy_object_proxy-1.4.3-cp27-cp27m-win32.whl", hash = "sha256:efa1909120ce98bbb3777e8b6f92237f5d5c8ea6758efea36a473e1d38f7d3e4"},
-    {file = "lazy_object_proxy-1.4.3-cp27-cp27m-win_amd64.whl", hash = "sha256:4677f594e474c91da97f489fea5b7daa17b5517190899cf213697e48d3902f5a"},
-    {file = "lazy_object_proxy-1.4.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:0c4b206227a8097f05c4dbdd323c50edf81f15db3b8dc064d08c62d37e1a504d"},
-    {file = "lazy_object_proxy-1.4.3-cp34-cp34m-manylinux1_x86_64.whl", hash = "sha256:d945239a5639b3ff35b70a88c5f2f491913eb94871780ebfabb2568bd58afc5a"},
-    {file = "lazy_object_proxy-1.4.3-cp34-cp34m-win32.whl", hash = "sha256:9651375199045a358eb6741df3e02a651e0330be090b3bc79f6d0de31a80ec3e"},
-    {file = "lazy_object_proxy-1.4.3-cp34-cp34m-win_amd64.whl", hash = "sha256:eba7011090323c1dadf18b3b689845fd96a61ba0a1dfbd7f24b921398affc357"},
-    {file = "lazy_object_proxy-1.4.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:48dab84ebd4831077b150572aec802f303117c8cc5c871e182447281ebf3ac50"},
-    {file = "lazy_object_proxy-1.4.3-cp35-cp35m-win32.whl", hash = "sha256:ca0a928a3ddbc5725be2dd1cf895ec0a254798915fb3a36af0964a0a4149e3db"},
-    {file = "lazy_object_proxy-1.4.3-cp35-cp35m-win_amd64.whl", hash = "sha256:194d092e6f246b906e8f70884e620e459fc54db3259e60cf69a4d66c3fda3449"},
-    {file = "lazy_object_proxy-1.4.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:97bb5884f6f1cdce0099f86b907aa41c970c3c672ac8b9c8352789e103cf3156"},
-    {file = "lazy_object_proxy-1.4.3-cp36-cp36m-win32.whl", hash = "sha256:cb2c7c57005a6804ab66f106ceb8482da55f5314b7fcb06551db1edae4ad1531"},
-    {file = "lazy_object_proxy-1.4.3-cp36-cp36m-win_amd64.whl", hash = "sha256:8d859b89baf8ef7f8bc6b00aa20316483d67f0b1cbf422f5b4dc56701c8f2ffb"},
-    {file = "lazy_object_proxy-1.4.3-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:1be7e4c9f96948003609aa6c974ae59830a6baecc5376c25c92d7d697e684c08"},
-    {file = "lazy_object_proxy-1.4.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d74bb8693bf9cf75ac3b47a54d716bbb1a92648d5f781fc799347cfc95952383"},
-    {file = "lazy_object_proxy-1.4.3-cp37-cp37m-win32.whl", hash = "sha256:9b15f3f4c0f35727d3a0fba4b770b3c4ebbb1fa907dbcc046a1d2799f3edd142"},
-    {file = "lazy_object_proxy-1.4.3-cp37-cp37m-win_amd64.whl", hash = "sha256:9254f4358b9b541e3441b007a0ea0764b9d056afdeafc1a5569eee1cc6c1b9ea"},
-    {file = "lazy_object_proxy-1.4.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:a6ae12d08c0bf9909ce12385803a543bfe99b95fe01e752536a60af2b7797c62"},
-    {file = "lazy_object_proxy-1.4.3-cp38-cp38-win32.whl", hash = "sha256:5541cada25cd173702dbd99f8e22434105456314462326f06dba3e180f203dfd"},
-    {file = "lazy_object_proxy-1.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239"},
+    {file = "lazy-object-proxy-1.5.2.tar.gz", hash = "sha256:5944a9b95e97de1980c65f03b79b356f30a43de48682b8bdd90aa5089f0ec1f4"},
+    {file = "lazy_object_proxy-1.5.2-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:e960e8be509e8d6d618300a6c189555c24efde63e85acaf0b14b2cd1ac743315"},
+    {file = "lazy_object_proxy-1.5.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:522b7c94b524389f4a4094c4bf04c2b02228454ddd17c1a9b2801fac1d754871"},
+    {file = "lazy_object_proxy-1.5.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:3782931963dc89e0e9a0ae4348b44762e868ea280e4f8c233b537852a8996ab9"},
+    {file = "lazy_object_proxy-1.5.2-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:429c4d1862f3fc37cd56304d880f2eae5bd0da83bdef889f3bd66458aac49128"},
+    {file = "lazy_object_proxy-1.5.2-cp35-cp35m-win32.whl", hash = "sha256:cd1bdace1a8762534e9a36c073cd54e97d517a17d69a17985961265be6d22847"},
+    {file = "lazy_object_proxy-1.5.2-cp35-cp35m-win_amd64.whl", hash = "sha256:ddbdcd10eb999d7ab292677f588b658372aadb9a52790f82484a37127a390108"},
+    {file = "lazy_object_proxy-1.5.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:ecb5dd5990cec6e7f5c9c1124a37cb2c710c6d69b0c1a5c4aa4b35eba0ada068"},
+    {file = "lazy_object_proxy-1.5.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:b6577f15d5516d7d209c1a8cde23062c0f10625f19e8dc9fb59268859778d7d7"},
+    {file = "lazy_object_proxy-1.5.2-cp36-cp36m-win32.whl", hash = "sha256:c8fe2d6ff0ff583784039d0255ea7da076efd08507f2be6f68583b0da32e3afb"},
+    {file = "lazy_object_proxy-1.5.2-cp36-cp36m-win_amd64.whl", hash = "sha256:fa5b2dee0e231fa4ad117be114251bdfe6afe39213bd629d43deb117b6a6c40a"},
+    {file = "lazy_object_proxy-1.5.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:1d33d6f789697f401b75ce08e73b1de567b947740f768376631079290118ad39"},
+    {file = "lazy_object_proxy-1.5.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:57fb5c5504ddd45ed420b5b6461a78f58cbb0c1b0cbd9cd5a43ad30a4a3ee4d0"},
+    {file = "lazy_object_proxy-1.5.2-cp37-cp37m-win32.whl", hash = "sha256:e7273c64bccfd9310e9601b8f4511d84730239516bada26a0c9846c9697617ef"},
+    {file = "lazy_object_proxy-1.5.2-cp37-cp37m-win_amd64.whl", hash = "sha256:6f4e5e68b7af950ed7fdb594b3f19a0014a3ace0fedb86acb896e140ffb24302"},
+    {file = "lazy_object_proxy-1.5.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:cadfa2c2cf54d35d13dc8d231253b7985b97d629ab9ca6e7d672c35539d38163"},
+    {file = "lazy_object_proxy-1.5.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:e7428977763150b4cf83255625a80a23dfdc94d43be7791ce90799d446b4e26f"},
+    {file = "lazy_object_proxy-1.5.2-cp38-cp38-win32.whl", hash = "sha256:2f2de8f8ac0be3e40d17730e0600619d35c78c13a099ea91ef7fb4ad944ce694"},
+    {file = "lazy_object_proxy-1.5.2-cp38-cp38-win_amd64.whl", hash = "sha256:38c3865bd220bd983fcaa9aa11462619e84a71233bafd9c880f7b1cb753ca7fa"},
+    {file = "lazy_object_proxy-1.5.2-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:8a44e9901c0555f95ac401377032f6e6af66d8fc1fbfad77a7a8b1a826e0b93c"},
+    {file = "lazy_object_proxy-1.5.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:fa7fb7973c622b9e725bee1db569d2c2ee64d2f9a089201c5e8185d482c7352d"},
+    {file = "lazy_object_proxy-1.5.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:71a1ef23f22fa8437974b2d60fedb947c99a957ad625f83f43fd3de70f77f458"},
+    {file = "lazy_object_proxy-1.5.2-cp39-cp39-win32.whl", hash = "sha256:ef3f5e288aa57b73b034ce9c1f1ac753d968f9069cd0742d1d69c698a0167166"},
+    {file = "lazy_object_proxy-1.5.2-cp39-cp39-win_amd64.whl", hash = "sha256:37d9c34b96cca6787fe014aeb651217944a967a5b165e2cacb6b858d2997ab84"},
 ]
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
@@ -919,8 +924,8 @@ pydantic = [
     {file = "pydantic-1.7.3.tar.gz", hash = "sha256:213125b7e9e64713d16d988d10997dabc6a1f73f3991e1ff8e35ebb1409c7dc9"},
 ]
 pylint = [
-    {file = "pylint-2.6.2-py3-none-any.whl", hash = "sha256:e71c2e9614a4f06e36498f310027942b0f4f2fde20aebb01655b31edc63b9eaf"},
-    {file = "pylint-2.6.2.tar.gz", hash = "sha256:718b74786ea7ed07aa0c58bf572154d4679f960d26e9641cc1de204a30b87fc9"},
+    {file = "pylint-2.7.1-py3-none-any.whl", hash = "sha256:a251b238db462b71d25948f940568bb5b3ae0e37dbaa05e10523f54f83e6cc7e"},
+    {file = "pylint-2.7.1.tar.gz", hash = "sha256:81ce108f6342421169ea039ff1f528208c99d2e5a9c4ca95cfc5291be6dfd982"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
@@ -1118,8 +1123,8 @@ urllib3 = [
     {file = "urllib3-1.26.3.tar.gz", hash = "sha256:de3eedaad74a2683334e282005cd8d7f22f4d55fa690a2a1020a416cb0a47e73"},
 ]
 uvicorn = [
-    {file = "uvicorn-0.13.3-py3-none-any.whl", hash = "sha256:1079c50a06f6338095b4f203e7861dbff318dde5f22f3a324fc6e94c7654164c"},
-    {file = "uvicorn-0.13.3.tar.gz", hash = "sha256:ef1e0bb5f7941c6fe324e06443ddac0331e1632a776175f87891c7bd02694355"},
+    {file = "uvicorn-0.13.4-py3-none-any.whl", hash = "sha256:7587f7b08bd1efd2b9bad809a3d333e972f1d11af8a5e52a9371ee3a5de71524"},
+    {file = "uvicorn-0.13.4.tar.gz", hash = "sha256:3292251b3c7978e8e4a7868f4baf7f7f7bb7e40c759ecc125c37e99cdea34202"},
 ]
 virtualenv = [
     {file = "virtualenv-20.4.2-py2.py3-none-any.whl", hash = "sha256:2be72df684b74df0ea47679a7df93fd0e04e72520022c57b479d8f881485dbe3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,13 @@ version = "0.1.0"
 [tool.poetry.dependencies]
 SQLAlchemy = "^1.3.23" 
 fastapi = "^0.63.0" 
+fastapi-hypermodel = "^0.2.0" 
 fastapi-pagination = {extras = ["sqlalchemy"], version = "^0.5.2"} 
 psycopg2-binary = "^2.8.6" # Needed for postgres
 pydantic = {extras = ["dotenv"], version = "^1.7.3"} 
 python = "^3.8" 
 requests = "^2.25.1" 
 uvicorn = "^0.13.3" 
-fastapi-hypermodel = "^0.1.0"
 
 [tool.poetry.dev-dependencies]
 bandit = "^1.7.0"

--- a/tests/test_laborders.py
+++ b/tests/test_laborders.py
@@ -14,7 +14,7 @@ def test_laborders_list(client):
     assert response.json()["items"] == [
         {
             "id": "LABORDER1",
-            "href": "/laborders/LABORDER1",
+            "links": {"self": "/laborders/LABORDER1"},
             "entered_at_description": None,
             "entered_at": None,
             "specimen_collected_time": "2020-03-16T00:00:00",
@@ -61,7 +61,7 @@ def test_laborders_list_filtered_ni(ukrdc3_session, client):
     assert response.json()["items"] == [
         {
             "id": "LABORDER_TEST1_1",
-            "href": "/laborders/LABORDER_TEST1_1",
+            "links": {"self": "/laborders/LABORDER_TEST1_1"},
             "entered_at_description": None,
             "entered_at": None,
             "specimen_collected_time": "2020-03-16T00:00:00",
@@ -74,14 +74,14 @@ def test_laborder(client):
     assert response.status_code == 200
     assert response.json() == {
         "id": "LABORDER1",
-        "href": "/laborders/LABORDER1",
+        "links": {"self": "/laborders/LABORDER1"},
         "entered_at_description": None,
         "entered_at": None,
         "specimen_collected_time": "2020-03-16T00:00:00",
         "result_items": [
             {
                 "id": "RESULTITEM1",
-                "href": "/resultitems/RESULTITEM1",
+                "links": {"self": "/resultitems/RESULTITEM1"},
                 "order_id": "LABORDER1",
                 "service_id": "SERVICE_ID",
                 "service_id_description": "SERVICE_ID_DESCRIPTION",

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1,15 +1,23 @@
 def test_record(client):
     response = client.get("/records/PYTEST01:PV:00000000A")
     assert response.status_code == 200
+    print(response.json())
     assert response.json() == {
         "pid": "PYTEST01:PV:00000000A",
-        "href": "/records/PYTEST01:PV:00000000A",
         "sendingfacility": "PATIENT_RECORD_SENDING_FACILITY_1",
         "sendingextract": "PV",
         "localpatientid": "00000000A",
         "ukrdcid": "000000000",
         "repository_creation_date": "2020-03-16T00:00:00",
         "repository_update_date": "2021-01-21T00:00:00",
+        "links": {
+            "self": "/records/PYTEST01:PV:00000000A",
+            "laborders": "/records/PYTEST01:PV:00000000A/laborders",
+            "observations": "/records/PYTEST01:PV:00000000A/observations",
+            "medications": "/records/PYTEST01:PV:00000000A/medications",
+            "surveys": "/records/PYTEST01:PV:00000000A/surveys",
+            "export-data": "/records/PYTEST01:PV:00000000A/export-data",
+        },
         "program_memberships": [],
         "patient": {
             "names": [{"given": "Patrick", "family": "Star"}],
@@ -56,7 +64,14 @@ def test_records(client):
         {
             "localpatientid": "00000000A",
             "pid": "PYTEST01:PV:00000000A",
-            "href": "/records/PYTEST01:PV:00000000A",
+            "links": {
+                "self": "/records/PYTEST01:PV:00000000A",
+                "laborders": "/records/PYTEST01:PV:00000000A/laborders",
+                "observations": "/records/PYTEST01:PV:00000000A/observations",
+                "medications": "/records/PYTEST01:PV:00000000A/medications",
+                "surveys": "/records/PYTEST01:PV:00000000A/surveys",
+                "export-data": "/records/PYTEST01:PV:00000000A/export-data",
+            },
             "repository_creation_date": "2020-03-16T00:00:00",
             "repository_update_date": "2021-01-21T00:00:00",
             "sendingextract": "PV",
@@ -87,7 +102,7 @@ def test_record_laborders(client):
             "entered_at": None,
             "entered_at_description": None,
             "id": "LABORDER1",
-            "href": "/laborders/LABORDER1",
+            "links": {"self": "/laborders/LABORDER1"},
             "specimen_collected_time": "2020-03-16T00:00:00",
         }
     ]

--- a/tests/test_resultitems.py
+++ b/tests/test_resultitems.py
@@ -68,7 +68,7 @@ def test_resultitems_list(client):
     assert response.json()["items"] == [
         {
             "id": "RESULTITEM1",
-            "href": "/resultitems/RESULTITEM1",
+            "links": {"self": "/resultitems/RESULTITEM1"},
             "order_id": "LABORDER1",
             "service_id": "SERVICE_ID",
             "service_id_description": "SERVICE_ID_DESCRIPTION",
@@ -88,7 +88,7 @@ def test_resultitems_list_filtered_ni(ukrdc3_session, client):
     assert response.json()["items"] == [
         {
             "id": "RESULTITEM_TEST2_1",
-            "href": "/resultitems/RESULTITEM_TEST2_1",
+            "links": {"self": "/resultitems/RESULTITEM_TEST2_1"},
             "order_id": "LABORDER_TEST2_1",
             "service_id": "SERVICE_ID_TEST2_1",
             "service_id_description": "SERVICE_ID_DESCRIPTION_TEST2_1",
@@ -108,7 +108,7 @@ def test_resultitems_list_filtered_service_id(ukrdc3_session, client):
     assert response.json()["items"] == [
         {
             "id": "RESULTITEM_TEST2_1",
-            "href": "/resultitems/RESULTITEM_TEST2_1",
+            "links": {"self": "/resultitems/RESULTITEM_TEST2_1"},
             "order_id": "LABORDER_TEST2_1",
             "service_id": "SERVICE_ID_TEST2_1",
             "service_id_description": "SERVICE_ID_DESCRIPTION_TEST2_1",
@@ -132,7 +132,7 @@ def test_resultitems_list_filtered_service_id_delete(ukrdc3_session, client):
     assert response.json()["items"] == [
         {
             "id": "RESULTITEM1",
-            "href": "/resultitems/RESULTITEM1",
+            "links": {"self": "/resultitems/RESULTITEM1"},
             "order_id": "LABORDER1",
             "service_id": "SERVICE_ID",
             "service_id_description": "SERVICE_ID_DESCRIPTION",
@@ -146,7 +146,7 @@ def test_resultitems_list_filtered_service_id_delete(ukrdc3_session, client):
     assert response.json()["items"] == [
         {
             "id": "LABORDER1",
-            "href": "/laborders/LABORDER1",
+            "links": {"self": "/laborders/LABORDER1"},
             "entered_at_description": None,
             "entered_at": None,
             "specimen_collected_time": "2020-03-16T00:00:00",
@@ -159,7 +159,7 @@ def test_resultitem_detail(client):
     assert response.status_code == 200
     assert response.json() == {
         "id": "RESULTITEM1",
-        "href": "/resultitems/RESULTITEM1",
+        "links": {"self": "/resultitems/RESULTITEM1"},
         "order_id": "LABORDER1",
         "service_id": "SERVICE_ID",
         "service_id_description": "SERVICE_ID_DESCRIPTION",

--- a/tests/test_workitems.py
+++ b/tests/test_workitems.py
@@ -11,7 +11,7 @@ def test_workitems_list(client):
     assert response.json()["items"] == [
         {
             "id": 1,
-            "href": "/workitems/1",
+            "links": {"self": "/workitems/1"},
             "person_id": 3,
             "master_id": 1,
             "type": 9,
@@ -24,7 +24,7 @@ def test_workitems_list(client):
         },
         {
             "id": 2,
-            "href": "/workitems/2",
+            "links": {"self": "/workitems/2"},
             "person_id": 4,
             "master_id": 1,
             "type": 9,
@@ -37,7 +37,7 @@ def test_workitems_list(client):
         },
         {
             "id": 3,
-            "href": "/workitems/3",
+            "links": {"self": "/workitems/3"},
             "person_id": 4,
             "master_id": 2,
             "type": 9,
@@ -57,7 +57,7 @@ def test_workitems_list_ukrdcid_filter_single(client):
     assert response.json()["items"] == [
         {
             "id": 1,
-            "href": "/workitems/1",
+            "links": {"self": "/workitems/1"},
             "person_id": 3,
             "master_id": 1,
             "type": 9,
@@ -70,7 +70,7 @@ def test_workitems_list_ukrdcid_filter_single(client):
         },
         {
             "id": 2,
-            "href": "/workitems/2",
+            "links": {"self": "/workitems/2"},
             "person_id": 4,
             "master_id": 1,
             "type": 9,
@@ -90,7 +90,7 @@ def test_workitems_list_ukrdcid_filter_multiple(client):
     assert response.json()["items"] == [
         {
             "id": 1,
-            "href": "/workitems/1",
+            "links": {"self": "/workitems/1"},
             "person_id": 3,
             "master_id": 1,
             "type": 9,
@@ -103,7 +103,7 @@ def test_workitems_list_ukrdcid_filter_multiple(client):
         },
         {
             "id": 2,
-            "href": "/workitems/2",
+            "links": {"self": "/workitems/2"},
             "person_id": 4,
             "master_id": 1,
             "type": 9,
@@ -116,7 +116,7 @@ def test_workitems_list_ukrdcid_filter_multiple(client):
         },
         {
             "id": 3,
-            "href": "/workitems/3",
+            "links": {"self": "/workitems/3"},
             "person_id": 4,
             "master_id": 2,
             "type": 9,
@@ -135,7 +135,7 @@ def test_workitem_detail(client):
     assert response.status_code == 200
     assert response.json() == {
         "id": 1,
-        "href": "/workitems/1",
+        "links": {"self": "/workitems/1"},
         "person_id": 3,
         "master_id": 1,
         "type": 9,
@@ -172,7 +172,7 @@ def test_workitem_detail(client):
         "related": [
             {
                 "id": 2,
-                "href": "/workitems/2",
+                "links": {"self": "/workitems/2"},
                 "person_id": 4,
                 "master_id": 1,
             }

--- a/ukrdc_fastapi/schemas/empi.py
+++ b/ukrdc_fastapi/schemas/empi.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import List, Optional
 
-from fastapi_hypermodel import HyperRef
+from fastapi_hypermodel import LinkSet, UrlFor
 from pydantic import Json
 
 from .base import OrmModel
@@ -51,11 +51,8 @@ class WorkItemSummarySchema(OrmModel):
     id: int
     person_id: int
     master_id: int
-    href: HyperRef
 
-    class Href:
-        endpoint = "workitem_detail"
-        values = {"workitem_id": "<id>"}
+    links = LinkSet({"self": UrlFor("workitem_detail", {"workitem_id": "<id>"})})
 
 
 class WorkItemShortSchema(OrmModel):
@@ -69,11 +66,8 @@ class WorkItemShortSchema(OrmModel):
     updated_by: Optional[str]
     update_description: Optional[str]
     attributes: Optional[Json]
-    href: HyperRef
 
-    class Href:
-        endpoint = "workitem_detail"
-        values = {"workitem_id": "<id>"}
+    links = LinkSet({"self": UrlFor("workitem_detail", {"workitem_id": "<id>"})})
 
 
 class WorkItemSchema(WorkItemShortSchema):

--- a/ukrdc_fastapi/schemas/laborder.py
+++ b/ukrdc_fastapi/schemas/laborder.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import List, Optional
 
-from fastapi_hypermodel import HyperRef
+from fastapi_hypermodel import LinkSet, UrlFor
 
 from .base import OrmModel
 
@@ -11,11 +11,8 @@ class LabOrderShortSchema(OrmModel):
     entered_at_description: Optional[str]
     entered_at: Optional[str]
     specimen_collected_time: datetime.datetime
-    href: HyperRef
 
-    class Href:
-        endpoint = "laborder_get"
-        values = {"order_id": "<id>"}
+    links = LinkSet({"self": UrlFor("laborder_get", {"order_id": "<id>"})})
 
 
 class ResultItemSchema(OrmModel):
@@ -25,11 +22,8 @@ class ResultItemSchema(OrmModel):
     service_id_description: str
     value: str
     value_units: Optional[str]
-    href: HyperRef
 
-    class Href:
-        endpoint = "resultitem_detail"
-        values = {"resultitem_id": "<id>"}
+    links = LinkSet({"self": UrlFor("resultitem_detail", {"resultitem_id": "<id>"})})
 
 
 class LabOrderSchema(LabOrderShortSchema):

--- a/ukrdc_fastapi/schemas/patientrecord.py
+++ b/ukrdc_fastapi/schemas/patientrecord.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import List, Optional
 
-from fastapi_hypermodel import HyperRef
+from fastapi_hypermodel import LinkSet, UrlFor
 
 from .base import OrmModel
 from .patient import PatientSchema
@@ -21,11 +21,17 @@ class PatientRecordShortSchema(OrmModel):
     ukrdcid: str
     repository_creation_date: datetime.datetime
     repository_update_date: datetime.datetime
-    href: HyperRef
 
-    class Href:
-        endpoint = "patient_record"
-        values = {"pid": "<pid>"}
+    links = LinkSet(
+        {
+            "self": UrlFor("patient_record", {"pid": "<pid>"}),
+            "laborders": UrlFor("patient_laborders", {"pid": "<pid>"}),
+            "observations": UrlFor("patient_observations", {"pid": "<pid>"}),
+            "medications": UrlFor("patient_medications", {"pid": "<pid>"}),
+            "surveys": UrlFor("patient_surveys", {"pid": "<pid>"}),
+            "export-data": UrlFor("patient_export", {"pid": "<pid>"}),
+        }
+    )
 
 
 class PatientRecordSchema(PatientRecordShortSchema):


### PR DESCRIPTION
Switches to FastAPI-HyperModel v0.2.0. 

This allows resources to specify multiple related links.

E.g. a patient record will now contain a `links` section like:

```python
        "links": {
            "self": "/records/PYTEST01:PV:00000000A",
            "laborders": "/records/PYTEST01:PV:00000000A/laborders",
            "observations": "/records/PYTEST01:PV:00000000A/observations",
            "medications": "/records/PYTEST01:PV:00000000A/medications",
            "surveys": "/records/PYTEST01:PV:00000000A/surveys",
            "export-data": "/records/PYTEST01:PV:00000000A/export-data",
        },
```