### PR TITLE
Added day-by-day error count to facility route

### DIFF
--- a/ukrdc_fastapi/query/errors.py
+++ b/ukrdc_fastapi/query/errors.py
@@ -92,8 +92,10 @@ def get_errors_history(
     since: Optional[datetime.datetime] = None,
     until: Optional[datetime.datetime] = None,
 ) -> Query:
+    trunc_func = func.date_trunc("day", Message.received)
+
     query = errorsdb.query(
-        func.date_trunc("day", Message.received),
+        trunc_func,
         Message.facility,
         Message.msg_status,
         func.count(Message.received),
@@ -111,15 +113,13 @@ def get_errors_history(
     since_datetime: datetime.datetime = (
         since or datetime.datetime.utcnow() - datetime.timedelta(days=365)
     )
-    query = query.filter(func.date_trunc("day", Message.received) >= since_datetime)
+    query = query.filter(trunc_func >= since_datetime)
 
     # Optionally filter out messages newer than `untildays`
     if until:
-        query = query.filter(func.date_trunc("day", Message.received) <= until)
+        query = query.filter(trunc_func <= until)
 
-    query = query.group_by(
-        func.date_trunc("day", Message.received), Message.facility, Message.msg_status
-    )
+    query = query.group_by(trunc_func, Message.facility, Message.msg_status)
     return query
 
 

--- a/ukrdc_fastapi/routers/api/facilities.py
+++ b/ukrdc_fastapi/routers/api/facilities.py
@@ -1,9 +1,12 @@
+import datetime
+
 from fastapi import APIRouter, Depends, Security
 from redis import Redis
 from sqlalchemy.orm import Session
 
 from ukrdc_fastapi.dependencies import get_errorsdb, get_redis, get_ukrdc3
 from ukrdc_fastapi.dependencies.auth import UKRDCUser, auth
+from ukrdc_fastapi.query.errors import get_errors_history
 from ukrdc_fastapi.query.facilities import (
     FacilityDetailsSchema,
     get_facilities,
@@ -34,3 +37,15 @@ def facility(
 ):
     """Retreive a list of on-record facilities"""
     return get_facility(ukrdc3, errorsdb, redis, code, user)
+
+
+@router.get("/{code}/error_history", response_model=list[tuple[datetime.datetime, int]])
+def facility_errrors_history(
+    code: str,
+    errorsdb: Session = Depends(get_errorsdb),
+    redis: Redis = Depends(get_redis),
+    user: UKRDCUser = Security(auth.get_user),
+):
+    """Retreive a list of on-record facilities"""
+    history = get_errors_history(errorsdb, user, facility=code).all()
+    return [(item[0], item[-1]) for item in history]


### PR DESCRIPTION
I'm not sure how useful this would be, so I'm leaving this as a draft for now.

Basically adds a `/api/facilities/{code}/error_history` route which provides a breakdown of error count per day for the last year.

**Note:** We can just about do this efficiently per-facility since the initial filter by facility reduces the work a lot. We can't easily do this for *all* facilities unless we migrate to asynchronous SQLAlchemy (not a small job, then run on a schedule and cache.

Might be useful for facilities to be able to see big spikes in error count?

Example response:
```json
[
...
 [
    "2021-05-27T00:00:00",
    12
  ],
  [
    "2021-05-28T00:00:00",
    9
  ],
  [
    "2021-06-01T00:00:00",
    18
  ],
  [
    "2021-06-03T00:00:00",
    21
  ]
...
]
```