### PR TITLE
Scheduled tasks

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -241,14 +241,27 @@ typing-extensions = ">=3.7.4,<4.0.0"
 
 [package.extras]
 gino = ["gino[starlette] (>=1.0.1,<2.0.0)", "SQLAlchemy (>=1.3.20,<2.0.0)", "sqlalchemy-stubs (>=0.4,<0.5)"]
-all = ["gino[starlette] (>=1.0.1,<2.0.0)", "SQLAlchemy (>=1.3.20,<2.0.0)", "sqlalchemy-stubs (>=0.4,<0.5)", "databases[mysql,postgresql,sqlite] (>=0.4.0,<0.5.0)", "orm (>=0.1.5,<0.2.0)", "tortoise-orm[aiosqlite,asyncpg,aiomysql] (>=0.16.18,<0.18.0)", "asyncpg (==0.23.0)", "ormar (>=0.10.5,<0.11.0)", "Django (<3.3.0)"]
+all = ["gino[starlette] (>=1.0.1,<2.0.0)", "SQLAlchemy (>=1.3.20,<2.0.0)", "sqlalchemy-stubs (>=0.4,<0.5)", "databases[sqlite,postgresql,mysql] (>=0.4.0,<0.5.0)", "orm (>=0.1.5,<0.2.0)", "tortoise-orm[aiomysql,aiosqlite,asyncpg] (>=0.16.18,<0.18.0)", "asyncpg (==0.23.0)", "ormar (>=0.10.5,<0.11.0)", "Django (<3.3.0)"]
 sqlalchemy = ["SQLAlchemy (>=1.3.20,<2.0.0)", "sqlalchemy-stubs (>=0.4,<0.5)"]
 asyncpg = ["SQLAlchemy (>=1.3.20,<2.0.0)", "asyncpg (==0.23.0)"]
-databases = ["databases[mysql,postgresql,sqlite] (>=0.4.0,<0.5.0)"]
-orm = ["databases[mysql,postgresql,sqlite] (>=0.4.0,<0.5.0)", "orm (>=0.1.5,<0.2.0)"]
-django = ["databases[mysql,postgresql,sqlite] (>=0.4.0,<0.5.0)", "Django (<3.3.0)"]
-tortoise = ["tortoise-orm[aiosqlite,asyncpg,aiomysql] (>=0.16.18,<0.18.0)"]
+databases = ["databases[sqlite,postgresql,mysql] (>=0.4.0,<0.5.0)"]
+orm = ["databases[sqlite,postgresql,mysql] (>=0.4.0,<0.5.0)", "orm (>=0.1.5,<0.2.0)"]
+django = ["databases[sqlite,postgresql,mysql] (>=0.4.0,<0.5.0)", "Django (<3.3.0)"]
+tortoise = ["tortoise-orm[aiomysql,aiosqlite,asyncpg] (>=0.16.18,<0.18.0)"]
 ormar = ["ormar (>=0.10.5,<0.11.0)"]
+
+[[package]]
+name = "fastapi-utils"
+version = "0.2.1"
+description = "Reusable utilities for FastAPI"
+category = "main"
+optional = false
+python-versions = ">=3.6,<4.0"
+
+[package.dependencies]
+fastapi = "*"
+pydantic = ">=1.0,<2.0"
+sqlalchemy = ">=1.3.12,<2.0.0"
 
 [[package]]
 name = "filelock"
@@ -975,7 +988,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9" 
-content-hash = "73d70159e9b561709542a77ebd593b9d65843e7322a99911bcf5b1359822223b"
+content-hash = "3ee89dece5ba3e17790a535e01ec7def17f9f6a9c9145fbc6d62a9bfa3d9c2c7"
 
 [metadata.files]
 anyio = [
@@ -1103,6 +1116,10 @@ fastapi-hypermodel = [
 fastapi-pagination = [
     {file = "fastapi-pagination-0.7.4.tar.gz", hash = "sha256:12d61d97454a3b56a4e7e12647ab37ab85aa40371101b64f0debda1f1a23e58f"},
     {file = "fastapi_pagination-0.7.4-py3-none-any.whl", hash = "sha256:f01808f5a216b30afab58028bb0c8c19b60109c954951560945e8bd21c63cd5d"},
+]
+fastapi-utils = [
+    {file = "fastapi-utils-0.2.1.tar.gz", hash = "sha256:0e6c7fc1870b80e681494957abf65d4f4f42f4c7f70005918e9181b22f1bd759"},
+    {file = "fastapi_utils-0.2.1-py3-none-any.whl", hash = "sha256:dd0be7dc7f03fa681b25487a206651d99f2330d5a567fb8ab6cb5f8a06a29360"},
 ]
 filelock = [
     {file = "filelock-3.0.12-py3-none-any.whl", hash = "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ sentry-sdk = "^1.1.0"
 ukrdc-sqla = "^1.2.1" 
 uvicorn = "^0.14.0" 
 mirth-client = "^1.2.0"
+fastapi-utils = "^0.2.1"
 
 [tool.poetry.dev-dependencies]
 bandit = "^1.7.0"

--- a/ukrdc_fastapi/config.py
+++ b/ukrdc_fastapi/config.py
@@ -18,7 +18,8 @@ class Settings(BaseSettings):
     # Redis cache expiry
     cache_channel_seconds: int = 86400
     cache_groups_seconds: int = 86400
-    cache_statistics_seconds: int = 900
+    cache_statistics_seconds: int = 3600
+    cache_dashboard_seconds: int = 900
 
     swagger_client_id: str = ""
     app_client_id: str = ""

--- a/ukrdc_fastapi/dependencies/auth.py
+++ b/ukrdc_fastapi/dependencies/auth.py
@@ -96,6 +96,14 @@ class URKDCAuth(OktaAuth):
         ]
         return [perm.split(":")[-1] for perm in unit_permissions]
 
+    @property
+    def superuser(self):
+        return UKRDCUser(
+            id="SUPERUSER",
+            email="SUPERUSER@UKRDC_FASTAPI",
+            permissions=self.permissions.all(),
+            scopes=["openid", "profile", "email", "offline_access"],
+        )
 
 auth = URKDCAuth(
     settings.oauth_issuer,

--- a/ukrdc_fastapi/dependencies/auth.py
+++ b/ukrdc_fastapi/dependencies/auth.py
@@ -98,6 +98,11 @@ class URKDCAuth(OktaAuth):
 
     @property
     def superuser(self):
+        """Generate a superuser object for internal use only
+
+        Returns:
+            UKRDCUser: User object with all available permissions
+        """
         return UKRDCUser(
             id="SUPERUSER",
             email="SUPERUSER@UKRDC_FASTAPI",

--- a/ukrdc_fastapi/dependencies/auth.py
+++ b/ukrdc_fastapi/dependencies/auth.py
@@ -105,6 +105,7 @@ class URKDCAuth(OktaAuth):
             scopes=["openid", "profile", "email", "offline_access"],
         )
 
+
 auth = URKDCAuth(
     settings.oauth_issuer,
     settings.oauth_audience,

--- a/ukrdc_fastapi/main.py
+++ b/ukrdc_fastapi/main.py
@@ -16,6 +16,7 @@ from ukrdc_fastapi.dependencies.auth import auth
 from ukrdc_fastapi.dependencies.database import Ukrdc3Session
 from ukrdc_fastapi.dependencies.sentry import add_sentry
 from ukrdc_fastapi.routers import api
+from ukrdc_fastapi.tasks import cache_all_facilities, cache_dash_stats
 
 # Create app
 
@@ -58,7 +59,10 @@ add_sentry(app)
 add_pagination(app)
 HyperModel.init_app(app)
 
-# Run startup checks
+# Attach event handlers
+
+app.router.add_event_handler("startup", cache_dash_stats)
+app.router.add_event_handler("startup", cache_all_facilities)
 
 
 class StartupError(RuntimeError):

--- a/ukrdc_fastapi/query/dashboard.py
+++ b/ukrdc_fastapi/query/dashboard.py
@@ -1,0 +1,51 @@
+from fastapi_hypermodel import HyperModel, UrlFor
+from redis import Redis
+from sqlalchemy.orm import Session
+from ukrdc_sqla.empi import MasterRecord, WorkItem
+
+from ukrdc_fastapi.config import settings
+from ukrdc_fastapi.utils.statistics import TotalDayPrev, total_day_prev
+
+
+class _DayPrevTotalSchema(HyperModel):
+    total: int
+    day: int
+    prev: int
+
+
+class WorkItemsDashSchema(_DayPrevTotalSchema):
+    href = UrlFor("workitems_list")
+
+
+class UKRDCRecordsDashSchema(_DayPrevTotalSchema):
+    href = UrlFor("master_records")
+
+
+def get_workitems_stats(jtrace: Session, redis: Redis, refresh: bool = False):
+    if redis.exists("dashboard:workitems") and not refresh:
+        return WorkItemsDashSchema(**redis.hgetall("dashboard:workitems"))
+
+    open_workitems_stats: TotalDayPrev = total_day_prev(
+        jtrace.query(WorkItem).filter(WorkItem.status == 1),
+        WorkItem,
+        "last_updated",
+    )
+    workitems = WorkItemsDashSchema(**open_workitems_stats.dict())
+    redis.hset("dashboard:workitems", mapping=open_workitems_stats.dict())  # type: ignore
+    redis.expire("dashboard:workitems", settings.cache_dashboard_seconds)
+    return workitems
+
+
+def get_empi_stats(jtrace: Session, redis: Redis, refresh: bool = False):
+    if redis.exists("dashboard:ukrdcrecords") and not refresh:
+        return UKRDCRecordsDashSchema(**redis.hgetall("dashboard:ukrdcrecords"))
+
+    ukrdc_masterrecords_stats: TotalDayPrev = total_day_prev(
+        jtrace.query(MasterRecord).filter(MasterRecord.nationalid_type == "UKRDC"),
+        MasterRecord,
+        "creation_date",
+    )
+    ukrdcrecords = UKRDCRecordsDashSchema(**ukrdc_masterrecords_stats.dict())
+    redis.hset("dashboard:ukrdcrecords", mapping=ukrdc_masterrecords_stats.dict())  # type: ignore
+    redis.expire("dashboard:ukrdcrecords", settings.cache_dashboard_seconds)
+    return ukrdcrecords

--- a/ukrdc_fastapi/query/dashboard.py
+++ b/ukrdc_fastapi/query/dashboard.py
@@ -21,7 +21,19 @@ class UKRDCRecordsDashSchema(_DayPrevTotalSchema):
     href = UrlFor("master_records")
 
 
-def get_workitems_stats(jtrace: Session, redis: Redis, refresh: bool = False):
+def get_workitems_stats(
+    jtrace: Session, redis: Redis, refresh: bool = False
+) -> WorkItemsDashSchema:
+    """Get and cache statistics about workitems from all facilities
+
+    Args:
+        jtrace (Session): SQLAlchemy session
+        redis (Redis): Redis session
+        refresh (bool, optional): Force refresh, ignoring cache. Defaults to False.
+
+    Returns:
+        WorkItemsDashSchema: WorkItem statistics
+    """
     if redis.exists("dashboard:workitems") and not refresh:
         return WorkItemsDashSchema(**redis.hgetall("dashboard:workitems"))
 
@@ -36,7 +48,19 @@ def get_workitems_stats(jtrace: Session, redis: Redis, refresh: bool = False):
     return workitems
 
 
-def get_empi_stats(jtrace: Session, redis: Redis, refresh: bool = False):
+def get_empi_stats(
+    jtrace: Session, redis: Redis, refresh: bool = False
+) -> UKRDCRecordsDashSchema:
+    """Get and cache statistics about records from all facilities
+
+    Args:
+        jtrace (Session): SQLAlchemy session
+        redis (Redis): Redis session
+        refresh (bool, optional): Force refresh, ignoring cache. Defaults to False.
+
+    Returns:
+        UKRDCRecordsDashSchema: EMPI statistics
+    """
     if redis.exists("dashboard:ukrdcrecords") and not refresh:
         return UKRDCRecordsDashSchema(**redis.hgetall("dashboard:ukrdcrecords"))
 

--- a/ukrdc_fastapi/query/facilities.py
+++ b/ukrdc_fastapi/query/facilities.py
@@ -118,7 +118,9 @@ def _get_and_cache_facility(
             records_with_errors=_get_error_ni_count(
                 errorsdb, auth.superuser, facility=code.code
             ),
-            patient_records=_get_record_stats(ukrdc3, auth.superuser, facility=code.code),
+            patient_records=_get_record_stats(
+                ukrdc3, auth.superuser, facility=code.code
+            ),
             errors=_get_error_stats(errorsdb, auth.superuser, facility=code.code),
         )
         redis.set(redis_key, statistics.json())  # type: ignore
@@ -134,7 +136,6 @@ def _get_and_cache_facility(
     )
 
     return facility_details
-
 
 
 def get_facilities(

--- a/ukrdc_fastapi/routers/api/dashboard.py
+++ b/ukrdc_fastapi/routers/api/dashboard.py
@@ -55,7 +55,7 @@ def _get_workitems_stats(jtrace: Session, redis: Redis, refresh: bool = False):
     workitems = WorkItemsDashSchema(**open_workitems_stats.dict())
     redis.hset("dashboard:workitems", mapping=open_workitems_stats.dict())  # type: ignore
     # Remove cached statistics after 15 minutes. Next request will re-query
-    redis.expire("dashboard:workitems", 900)
+    redis.expire("dashboard:workitems", settings.cache_dashboard_seconds)
     return workitems
 
 
@@ -71,7 +71,7 @@ def _get_empi_stats(jtrace: Session, redis: Redis, refresh: bool = False):
     ukrdcrecords = UKRDCRecordsDashSchema(**ukrdc_masterrecords_stats.dict())
     redis.hset("dashboard:ukrdcrecords", mapping=ukrdc_masterrecords_stats.dict())  # type: ignore
     # Remove cached statistics after 15 minutes. Next request will re-query
-    redis.expire("dashboard:ukrdcrecords", 900)
+    redis.expire("dashboard:ukrdcrecords", settings.cache_dashboard_seconds)
     return ukrdcrecords
 
 

--- a/ukrdc_fastapi/routers/api/dashboard.py
+++ b/ukrdc_fastapi/routers/api/dashboard.py
@@ -1,39 +1,21 @@
-import datetime
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Security
-from fastapi_hypermodel import HyperModel, UrlFor
-from mirth_client.models import ChannelStatistics
 from pydantic import BaseModel
 from redis import Redis
 from sqlalchemy.orm import Session
-from ukrdc_sqla.empi import MasterRecord, WorkItem
 
 from ukrdc_fastapi.config import settings
 from ukrdc_fastapi.dependencies import get_jtrace, get_redis
 from ukrdc_fastapi.dependencies.auth import Permissions, UKRDCUser, auth
-from ukrdc_fastapi.utils.statistics import TotalDayPrev, total_day_prev
+from ukrdc_fastapi.query.dashboard import (
+    UKRDCRecordsDashSchema,
+    WorkItemsDashSchema,
+    get_empi_stats,
+    get_workitems_stats,
+)
 
 router = APIRouter(tags=["Summary Dashboard"])
-
-
-class ChannelDashStatisticsSchema(ChannelStatistics):
-    name: Optional[str]
-    updated: Optional[datetime.datetime]
-
-
-class _DayPrevTotalSchema(HyperModel):
-    total: int
-    day: int
-    prev: int
-
-
-class WorkItemsDashSchema(_DayPrevTotalSchema):
-    href = UrlFor("workitems_list")
-
-
-class UKRDCRecordsDashSchema(_DayPrevTotalSchema):
-    href = UrlFor("master_records")
 
 
 class DashboardSchema(BaseModel):
@@ -41,38 +23,6 @@ class DashboardSchema(BaseModel):
     warnings: list[str]
     workitems: Optional[WorkItemsDashSchema] = None
     ukrdcrecords: Optional[UKRDCRecordsDashSchema] = None
-
-
-def _get_workitems_stats(jtrace: Session, redis: Redis, refresh: bool = False):
-    if redis.exists("dashboard:workitems") and not refresh:
-        return WorkItemsDashSchema(**redis.hgetall("dashboard:workitems"))
-
-    open_workitems_stats: TotalDayPrev = total_day_prev(
-        jtrace.query(WorkItem).filter(WorkItem.status == 1),
-        WorkItem,
-        "last_updated",
-    )
-    workitems = WorkItemsDashSchema(**open_workitems_stats.dict())
-    redis.hset("dashboard:workitems", mapping=open_workitems_stats.dict())  # type: ignore
-    # Remove cached statistics after 15 minutes. Next request will re-query
-    redis.expire("dashboard:workitems", settings.cache_dashboard_seconds)
-    return workitems
-
-
-def _get_empi_stats(jtrace: Session, redis: Redis, refresh: bool = False):
-    if redis.exists("dashboard:ukrdcrecords") and not refresh:
-        return UKRDCRecordsDashSchema(**redis.hgetall("dashboard:ukrdcrecords"))
-
-    ukrdc_masterrecords_stats: TotalDayPrev = total_day_prev(
-        jtrace.query(MasterRecord).filter(MasterRecord.nationalid_type == "UKRDC"),
-        MasterRecord,
-        "creation_date",
-    )
-    ukrdcrecords = UKRDCRecordsDashSchema(**ukrdc_masterrecords_stats.dict())
-    redis.hset("dashboard:ukrdcrecords", mapping=ukrdc_masterrecords_stats.dict())  # type: ignore
-    # Remove cached statistics after 15 minutes. Next request will re-query
-    redis.expire("dashboard:ukrdcrecords", settings.cache_dashboard_seconds)
-    return ukrdcrecords
 
 
 @router.get("/", response_model=DashboardSchema)
@@ -89,7 +39,7 @@ def dashboard(
 
     # Admin statistics
     if Permissions.UNIT_WILDCARD in units:
-        dash.workitems = _get_workitems_stats(jtrace, redis, refresh=refresh)
-        dash.ukrdcrecords = _get_empi_stats(jtrace, redis, refresh=refresh)
+        dash.workitems = get_workitems_stats(jtrace, redis, refresh=refresh)
+        dash.ukrdcrecords = get_empi_stats(jtrace, redis, refresh=refresh)
 
     return dash

--- a/ukrdc_fastapi/tasks.py
+++ b/ukrdc_fastapi/tasks.py
@@ -1,0 +1,35 @@
+import logging
+
+from fastapi_utils.tasks import repeat_every
+from ukrdc_sqla.ukrdc import Code
+
+from ukrdc_fastapi.config import settings
+from ukrdc_fastapi.dependencies import get_redis
+from ukrdc_fastapi.dependencies.database import (
+    ErrorsSession,
+    JtraceSession,
+    Ukrdc3Session,
+)
+from ukrdc_fastapi.query.facilities import _get_and_cache_facility
+from ukrdc_fastapi.routers.api.dashboard import _get_empi_stats, _get_workitems_stats
+
+
+@repeat_every(seconds=settings.cache_statistics_seconds)
+def cache_all_facilities() -> None:
+    ukrdc3 = Ukrdc3Session()
+    errorsdb = ErrorsSession()
+    redis = get_redis()
+    logging.info("Refreshing facility statistics")
+    codes = ukrdc3.query(Code).filter(Code.coding_standard == "RR1+").all()
+    for code in codes:
+        logging.debug(f"Caching {code.code}")
+        _get_and_cache_facility(code, ukrdc3, errorsdb, redis)
+
+
+@repeat_every(seconds=settings.cache_dashboard_seconds)
+def cache_dash_stats() -> None:
+    jtrace = JtraceSession()
+    redis = get_redis()
+    logging.info("Refreshing admin statistics")
+    _get_workitems_stats(jtrace, redis, refresh=True)
+    _get_empi_stats(jtrace, redis, refresh=True)

--- a/ukrdc_fastapi/tasks.py
+++ b/ukrdc_fastapi/tasks.py
@@ -16,18 +16,20 @@ from ukrdc_fastapi.query.facilities import _get_and_cache_facility
 
 @repeat_every(seconds=settings.cache_statistics_seconds)
 def cache_all_facilities() -> None:
+    """FastAPI Utils task to refresh statistics for each facility"""
     ukrdc3 = Ukrdc3Session()
     errorsdb = ErrorsSession()
     redis = get_redis()
     logging.info("Refreshing facility statistics")
     codes = ukrdc3.query(Code).filter(Code.coding_standard == "RR1+").all()
     for code in codes:
-        logging.debug(f"Caching {code.code}")
+        logging.debug("Caching %s", code.code)
         _get_and_cache_facility(code, ukrdc3, errorsdb, redis)
 
 
 @repeat_every(seconds=settings.cache_dashboard_seconds)
 def cache_dash_stats() -> None:
+    """FastAPI Utils task to refresh statistics for the admin dashboard"""
     jtrace = JtraceSession()
     redis = get_redis()
     logging.info("Refreshing admin statistics")

--- a/ukrdc_fastapi/tasks.py
+++ b/ukrdc_fastapi/tasks.py
@@ -10,8 +10,8 @@ from ukrdc_fastapi.dependencies.database import (
     JtraceSession,
     Ukrdc3Session,
 )
+from ukrdc_fastapi.query.dashboard import get_empi_stats, get_workitems_stats
 from ukrdc_fastapi.query.facilities import _get_and_cache_facility
-from ukrdc_fastapi.routers.api.dashboard import _get_empi_stats, _get_workitems_stats
 
 
 @repeat_every(seconds=settings.cache_statistics_seconds)
@@ -31,5 +31,5 @@ def cache_dash_stats() -> None:
     jtrace = JtraceSession()
     redis = get_redis()
     logging.info("Refreshing admin statistics")
-    _get_workitems_stats(jtrace, redis, refresh=True)
-    _get_empi_stats(jtrace, redis, refresh=True)
+    get_workitems_stats(jtrace, redis, refresh=True)
+    get_empi_stats(jtrace, redis, refresh=True)


### PR DESCRIPTION
Uses https://fastapi-utils.davidmontague.xyz/user-guide/repeated-tasks/ to add scheduled background tasks running in separate threads for long, blocking operations.

Currently used to refresh facility and admin statistics and add them to Redis.