### PR TITLE
Added generic message history viewer to MasterRecord resources

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -633,8 +633,22 @@ def populate_errorsdb_session(session):
         status="STATUS2",
     )
 
+    message_1 = ErrorMessage(
+        id=3,
+        message_id=3,
+        channel_id="MIRTH-CHANNEL-UUID",
+        received=datetime(2021, 1, 1),
+        msg_status="RECEIVED",
+        ni="999999999",
+        filename="FILENAME_3.XML",
+        facility="TEST_SENDING_FACILITY_1",
+        error=None,
+        status="STATUS3",
+    )
+
     session.add(error_1)
     session.add(error_2)
+    session.add(message_1)
 
     session.commit()
 

--- a/tests/test_routers/test_masterrecords.py
+++ b/tests/test_routers/test_masterrecords.py
@@ -102,6 +102,15 @@ def test_masterrecord_errors(client):
     assert returned_ids == {1}
 
 
+def test_masterrecord_messages(client):
+    response = client.get("/api/v1/masterrecords/1/messages")
+    assert response.status_code == 200
+
+    errors = [MessageSchema(**item) for item in response.json()["items"]]
+    returned_ids = {item.id for item in errors}
+    assert returned_ids == {1, 3}
+
+
 def test_masterrecord_persons(client):
     response = client.get("/api/v1/masterrecords/1/persons")
     assert response.status_code == 200

--- a/ukrdc_fastapi/routers/api/v1/errors/messages.py
+++ b/ukrdc_fastapi/routers/api/v1/errors/messages.py
@@ -103,7 +103,7 @@ async def error_source(
         message.connector_messages.values()
     )[0]
 
-    message_data: Optional[ConnectorMessageData]
+    message_data: Optional[ConnectorMessageData] = None
 
     # Prioritise encoded message over raw
     if first_connector_message.encoded:

--- a/ukrdc_fastapi/schemas/empi.py
+++ b/ukrdc_fastapi/schemas/empi.py
@@ -28,6 +28,7 @@ class MasterRecordSchema(OrmModel):
             "statistics": UrlFor("master_record_statistics", {"record_id": "<id>"}),
             "related": UrlFor("master_record_related", {"record_id": "<id>"}),
             "errors": UrlFor("master_record_errors", {"record_id": "<id>"}),
+            "messages": UrlFor("master_record_messages", {"record_id": "<id>"}),
             "linkrecords": UrlFor("master_record_linkrecords", {"record_id": "<id>"}),
             "persons": UrlFor("master_record_persons", {"record_id": "<id>"}),
             "workitems": UrlFor("master_record_workitems", {"record_id": "<id>"}),


### PR DESCRIPTION
To do:

- [x] Unit test for /{id}/messages route
  - [x] Add non-error messages to test DB