### PR TITLE
Exclude self from related records

### DIFF
--- a/tests/test_query/test_masterrecords.py
+++ b/tests/test_query/test_masterrecords.py
@@ -74,3 +74,10 @@ def test_masterrecord_related(jtrace_session, superuser):
 
     # Check MR3 is identified as related to MR1
     assert {record.id for record in records} == {1, 999}
+
+    records_excl_self = masterrecords.get_masterrecords_related_to_masterrecord(
+        jtrace_session, 1, superuser, exclude_self=True
+    )
+
+    # Check MR3 is identified as related to MR1
+    assert {record.id for record in records_excl_self} == {999}

--- a/tests/test_routers/test_masterrecords.py
+++ b/tests/test_routers/test_masterrecords.py
@@ -56,13 +56,21 @@ def test_masterrecord_related(client, jtrace_session):
     jtrace_session.add(link_record_999)
     jtrace_session.commit()
 
+    # Check expected link
+
     response = client.get("/api/v1/masterrecords/1/related")
     assert response.status_code == 200
-
-    # Check MR3 is identified as related to MR1
     mrecs = [MasterRecordSchema(**item) for item in response.json()]
     returned_ids = {item.id for item in mrecs}
-    assert returned_ids == {1, 999}
+    assert returned_ids == {999}
+
+    # Test reciprocal link
+
+    response_reciprocal = client.get("/api/v1/masterrecords/999/related")
+    assert response_reciprocal.status_code == 200
+    mrecs = [MasterRecordSchema(**item) for item in response_reciprocal.json()]
+    returned_ids = {item.id for item in mrecs}
+    assert returned_ids == {1}
 
 
 def test_masterrecord_statistics(client):

--- a/ukrdc_fastapi/query/masterrecords.py
+++ b/ukrdc_fastapi/query/masterrecords.py
@@ -89,7 +89,7 @@ def get_masterrecord(jtrace: Session, record_id: int, user: UKRDCUser) -> Master
 
 
 def get_masterrecords_related_to_masterrecord(
-    jtrace: Session, record_id: int, user: UKRDCUser
+    jtrace: Session, record_id: int, user: UKRDCUser, exclude_self: bool = False
 ) -> Query:
     """Get a query of MasterRecords related via the LinkRecord network to a given MasterRecord
 
@@ -105,6 +105,10 @@ def get_masterrecords_related_to_masterrecord(
     related_master_ids, _ = find_related_ids(jtrace, {record_id}, set())
     # Return a jtrace query of the matched master records
     records = jtrace.query(MasterRecord).filter(MasterRecord.id.in_(related_master_ids))
+
+    # Exclude self from related items
+    if exclude_self:
+        records = records.filter(MasterRecord.id != record_id)
 
     return _apply_query_permissions(records, user)
 

--- a/ukrdc_fastapi/routers/api/v1/masterrecords/record_id.py
+++ b/ukrdc_fastapi/routers/api/v1/masterrecords/record_id.py
@@ -150,7 +150,9 @@ def master_record_related(
     jtrace: Session = Depends(get_jtrace),
 ):
     """Retreive a list of other master records related to a particular master record"""
-    return get_masterrecords_related_to_masterrecord(jtrace, record_id, user).all()
+    return get_masterrecords_related_to_masterrecord(
+        jtrace, record_id, user, exclude_self=True
+    ).all()
 
 
 @router.get(


### PR DESCRIPTION
Prevents related master records API route from including the original record itself.

Makes self-exclusion optional on `get_masterrecords_related_to_masterrecord` so that other functions can still use `get_masterrecords_related_to_masterrecord` to retrieve a full set.