### PR TITLE
Simpler search

### DIFF
--- a/tests/test_routers/test_search.py
+++ b/tests/test_routers/test_search.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime
 
 from stdnum.gb import nhs
-from ukrdc_sqla.empi import MasterRecord
+from ukrdc_sqla.empi import LinkRecord, MasterRecord, Person, PidXRef
 
 TEST_NUMBERS = [
     "9434765870",
@@ -18,16 +18,44 @@ TEST_NUMBERS = [
 
 def _commit_extra_patients(session, number_type="NHS"):
     for index, number in enumerate(TEST_NUMBERS):
+        dob = datetime(1950, 1, (index + 11) % 28)
+        localid = f"PYTEST:SEARCH:{number}"
         master_record = MasterRecord(
             id=index + 99,
             status=0,
-            last_updated=datetime(2020, 3, (index + 11) % 28),
-            date_of_birth=datetime(1950, 1, (index + 11) % 28),
+            last_updated=dob,
+            date_of_birth=dob,
             nationalid=number,
             nationalid_type=number_type,
             effective_date=datetime(2020, 3, 16),
         )
+        person = Person(
+            id=index + 99,
+            originator="UKRDC",
+            localid=localid,
+            localid_type="CLPID",
+            date_of_birth=dob,
+            gender="9",
+        )
+        link_record = LinkRecord(
+            id=index + 99,
+            person_id=index + 99,
+            master_id=index + 99,
+            link_type=0,
+            link_code=0,
+            last_updated=datetime(2019, 1, 1),
+        )
+        xref = PidXRef(
+            id=index + 99,
+            pid=localid,
+            sending_facility="TEST_SENDING_FACILITY_1",
+            sending_extract="XREF_SENDING_EXTRACT_1",
+            localid=number,
+        )
         session.add(master_record)
+        session.add(person)
+        session.add(link_record)
+        session.add(xref)
         session.commit()
 
 
@@ -46,13 +74,13 @@ def test_search_all(jtrace_session, client):
         assert returned_ids == {index + 99}
 
 
-def test_search_nhsno(jtrace_session, client):
+def test_search_mrn(jtrace_session, client):
     # Add extra test items
     _commit_extra_patients(jtrace_session, number_type="NHS")
 
     # Search for each item individually
     for index, number in enumerate(TEST_NUMBERS):
-        url = f"/api/v1/search/?nhs_number={number}"
+        url = f"/api/v1/search/?mrn_number={number}"
 
         response = client.get(url)
         assert response.status_code == 200
@@ -61,14 +89,14 @@ def test_search_nhsno(jtrace_session, client):
         assert returned_ids == {index + 99}
 
 
-def test_search_multiple_nhsno(jtrace_session, client):
+def test_search_multiple_mrn(jtrace_session, client):
     # Add extra test items
     _commit_extra_patients(jtrace_session, number_type="NHS")
 
     # Add extra test items
     path = "/api/v1/search/?"
     for number in TEST_NUMBERS[:5]:
-        path += f"nhs_number={number}&"
+        path += f"mrn_number={number}&"
     path = path.rstrip("&")
 
     response = client.get(path)

--- a/tests/test_utils/test_search.py
+++ b/tests/test_utils/test_search.py
@@ -26,21 +26,21 @@ def test_term_is_exact(term, expected):
         ('t"er"m', 't"er"m%'),
     ],
 )
-def test_convert_query_to_ilike(term, expected):
-    assert search._convert_query_to_ilike(term) == expected
+def test_convert_query_to_pg_like(term, expected):
+    assert search._convert_query_to_pg_like(term) == expected
 
 
 @pytest.mark.parametrize(
     "term,expected",
     [
         ('"term"', "term"),
-        ("term", "%term%"),
-        ('"term', '%"term%'),
-        ('t"er"m', '%t"er"m%'),
+        ("term", "term%"),
+        ('"term', '"term%'),
+        ('t"er"m', 't"er"m%'),
     ],
 )
-def test_convert_query_to_ilike_double_ended(term, expected):
-    assert search._convert_query_to_ilike(term, double_ended=True) == expected
+def test_convert_query_to_pg_like_double_ended(term, expected):
+    assert search._convert_query_to_pg_like(term) == expected
 
 
 @pytest.mark.parametrize(
@@ -52,16 +52,13 @@ def test_convert_query_to_ilike_double_ended(term, expected):
         ("632 189 2009", "6321892009"),
         ("632-189-2009", "6321892009"),
         ("632 - 189 - 2009", "6321892009"),
-        ("1234", None),
-        ("1234567890", None),
+        ("1234", "1234"),
+        ("1234567890", "1234567890"),
     ],
 )
-def test_implicit_nhs_number(term, expected):
+def test_nhs_number_normalization(term, expected):
     s = search.SearchSet()
-    s.add_nhs_number(term)
+    s.add_mrn_number(term)
 
-    if expected:
-        assert len(s.nhs_numbers) == 1
-        assert s.nhs_numbers[0] == expected
-    else:
-        assert len(s.nhs_numbers) == 0
+    assert len(s.mrn_numbers) == 1
+    assert s.mrn_numbers[0] == expected

--- a/ukrdc_fastapi/routers/api/v1/search.py
+++ b/ukrdc_fastapi/routers/api/v1/search.py
@@ -20,22 +20,20 @@ router = APIRouter(tags=["Search"])
     dependencies=[Security(auth.permission([Permissions.READ_RECORDS]))],
 )
 def search_masterrecords(
-    nhs_number: list[str] = QueryParam([]),
+    pid: list[str] = QueryParam([]),
     mrn_number: list[str] = QueryParam([]),
     ukrdc_number: list[str] = QueryParam([]),
     full_name: list[str] = QueryParam([]),
-    pidx: list[str] = QueryParam([]),
     dob: list[str] = QueryParam([]),
     search: list[str] = QueryParam([]),
     number_type: list[str] = QueryParam([]),
     include_ukrdc: bool = False,
-    only_ukrdc: bool = False,
     user: UKRDCUser = Security(auth.get_user()),
     jtrace: Session = Depends(get_jtrace),
 ):
     """Search the EMPI for a particular master record"""
     matched_ids = search_masterrecord_ids(
-        nhs_number, mrn_number, ukrdc_number, full_name, pidx, dob, search, jtrace
+        mrn_number, ukrdc_number, full_name, pid, dob, search, jtrace
     )
 
     matched_records = get_masterrecords(jtrace, user).filter(
@@ -50,10 +48,6 @@ def search_masterrecords(
     if not include_ukrdc:
         matched_records = matched_records.filter(
             MasterRecord.nationalid_type != "UKRDC"
-        )
-    if only_ukrdc:
-        matched_records = matched_records.filter(
-            MasterRecord.nationalid_type == "UKRDC"
         )
 
     return paginate(matched_records)

--- a/ukrdc_fastapi/utils/search/masterrecords.py
+++ b/ukrdc_fastapi/utils/search/masterrecords.py
@@ -10,7 +10,6 @@ from stdnum.util import isdigits
 from ukrdc_sqla.empi import LinkRecord, MasterRecord, Person, PidXRef
 
 from ukrdc_fastapi.utils import parse_date
-from ukrdc_fastapi.utils.links import find_related_ids
 
 
 class SearchSet:

--- a/ukrdc_fastapi/utils/search/masterrecords.py
+++ b/ukrdc_fastapi/utils/search/masterrecords.py
@@ -1,4 +1,5 @@
 import datetime
+import re
 from typing import Iterable, Optional, Union
 
 from sqlalchemy.orm import Session
@@ -6,7 +7,7 @@ from sqlalchemy.sql.expression import or_
 from sqlalchemy.sql.functions import concat
 from stdnum.gb import nhs
 from stdnum.util import isdigits
-from ukrdc_sqla.empi import MasterRecord, Person, PidXRef
+from ukrdc_sqla.empi import LinkRecord, MasterRecord, Person, PidXRef
 
 from ukrdc_fastapi.utils import parse_date
 from ukrdc_fastapi.utils.links import find_related_ids
@@ -17,14 +18,12 @@ class SearchSet:
         # Dates
         self.dates: list[datetime.date] = []  # DoB, DoD etc
 
-        # String IDs
-        self.nhs_numbers: list[str] = []  # NHS, CHI, or HSC
-        self.mrn_numbers: list[str] = []  # Any unit-specific local ID
+        # External IDs
+        self.mrn_numbers: list[str] = []
 
-        # Integer IDs
+        # Internal IDs
         self.ukrdc_numbers: list[str] = []  # UKRDCID
         self.pids: list[str] = []  # Internal PIDs
-        self.empi_ids: list[str] = []  # MasterRecord or Person IDs
 
         # Chars
         self.names: list[str] = []  # Patient names
@@ -41,19 +40,16 @@ class SearchSet:
         if parsed_date:
             self.dates.append(parsed_date.date())
 
-    def add_nhs_number(self, item: str):
-        """Add an NHS number string to the search query set.
-        If the string cannot be parsed as an NHS number, it will be ignored"""
-        if nhs.is_valid(item):
-            self.nhs_numbers.append(nhs.compact(item))
-        elif nhs.is_valid(item.zfill(10)):
-            self.nhs_numbers.append(nhs.compact(item.zfill(10)))
-
     def add_mrn_number(self, item: str):
         """Add an MRN number formatted string to the search query set.
         If the string cannot be parsed as an MRN number, it will be ignored"""
-
-        if len(item) <= 17:
+        # Compact NHS numbers before searching
+        if nhs.is_valid(item):
+            self.mrn_numbers.append(nhs.compact(item))
+        elif nhs.is_valid(item.zfill(10)):
+            self.mrn_numbers.append(nhs.compact(item.zfill(10)))
+        # Search anything else as-is
+        elif len(item) <= 17:
             self.mrn_numbers.append(item)
 
     def add_ukrdc_number(self, item: str):
@@ -70,18 +66,11 @@ class SearchSet:
         if isdigits(item) and (1000000000 <= int(item) <= 10000000000):
             self.pids.append(item)
 
-    def add_empi_id(self, item: str):
-        """Add an EMPI ID formatted string to the search query set.
-        If the string cannot be parsed as an EMPI ID, it will be ignored"""
-
-        # Extract EMPI IDs (by int4 type)
-        if isdigits(item) and (-2147483648 <= int(item) <= 2147483647):
-            self.empi_ids.append(item)
-
     def add_name(self, item: str):
         """Add a name string to the search query set."""
-
-        self.names.append(item)
+        # Exclude strings containing only 0-9, -, _, ., or /
+        if not re.match(r"^[0-9-/_.]*$", item):
+            self.names.append(item)
 
     def add_terms(self, terms: list[str]):
         """
@@ -95,9 +84,6 @@ class SearchSet:
             # Extract dates
             self.add_date(item)
 
-            # Extract NHS numbers
-            self.add_nhs_number(item)
-
             # Extract MRN numbers
             self.add_mrn_number(item)
 
@@ -106,9 +92,6 @@ class SearchSet:
 
             # Extract PIDs (by range)
             self.add_pid(item)
-
-            # Extract EMPI IDs (by int4 type)
-            self.add_empi_id(item)
 
             # Absolutely anything can be a name
             self.add_name(item)
@@ -127,44 +110,25 @@ def _term_is_exact(item: str) -> bool:
     return item[0] == '"' and item[-1] == '"'
 
 
-def _convert_query_to_ilike(item: str, double_ended: bool = False) -> str:
-    """Convert a search query into a postgres ilike expression.
+def _convert_query_to_pg_like(item: str) -> str:
+    """Convert a search query into a postgres LIKE expression.
     E.g. a term wrapped in quotes will be matched exactly (but case
     insensitive), but without quotes will be fuzzy-searched
 
     Args:
         item (str): Search term
-        double_ended (bool, optional): Match prefix as well as suffix. Defaults to False.
 
     Returns:
         str: Postgres ilike expression string
     """
     if _term_is_exact(item):
         return item.strip('"')
-    if double_ended:
-        return f"%{item}%"
     return f"{item}%"
-
-
-def masterrecord_ids_from_nhs_no(session: Session, nhs_nos: Iterable[str]):
-    """Finds IDs from NHS number."""
-    conditions = [MasterRecord.nationalid.ilike(nhs_no.strip()) for nhs_no in nhs_nos]
-    matched_ids = {
-        record.id
-        for record in session.query(MasterRecord)
-        .filter(
-            or_(*conditions),
-            MasterRecord.nationalid_type.in_(["NHS", "HSC", "CHI"]),
-        )
-        .all()
-    }
-
-    return matched_ids
 
 
 def masterrecord_ids_from_mrn_no(session: Session, mrn_nos: Iterable[str]):
     """
-    Finds Master Record IDs from MRN number.
+    Finds Master Record IDs from MRN/NHS/HSC/CHI/RADAR number.
 
     Naievely we would just match Person.localid, however the EMPI has
     an extra step to work around MRNs (local IDs) changing.
@@ -177,13 +141,28 @@ def masterrecord_ids_from_mrn_no(session: Session, mrn_nos: Iterable[str]):
     """
     conditions = [PidXRef.localid.like(mrn_no) for mrn_no in mrn_nos]
     matched_persons = session.query(Person).join(PidXRef).filter(or_(*conditions)).all()
+    matched_ids = {
+        link.master_id
+        for link in session.query(LinkRecord).filter(
+            LinkRecord.person_id.in_({person.id for person in matched_persons})
+        )
+    }
+    return matched_ids
 
-    # Find all related master record IDs by recursing through link records
-    related_master_ids, _ = find_related_ids(
-        session, set(), {person.localid for person in matched_persons}
-    )
 
-    return related_master_ids
+def masterrecord_ids_from_pid(session: Session, pid_nos: Iterable[str]):
+    """
+    Finds Master Record IDs from PIDs
+    """
+    conditions = [Person.localid.like(pid_no) for pid_no in pid_nos]
+    matched_persons: list[Person] = session.query(Person).filter(or_(*conditions)).all()
+    matched_ids = {
+        link.master_id
+        for link in session.query(LinkRecord).filter(
+            LinkRecord.person_id.in_({person.id for person in matched_persons})
+        )
+    }
+    return matched_ids
 
 
 def masterrecord_ids_from_ukrdc_no(session: Session, ukrdc_nos: Iterable[str]):
@@ -214,13 +193,13 @@ def masterrecord_ids_from_full_name(session: Session, names: Iterable[str]):
     conditions = []
 
     for name in names:
-        query_term: str = _convert_query_to_ilike(name)
+        query_term: str = _convert_query_to_pg_like(name).upper()
 
         conditions.append(
-            concat(MasterRecord.givenname, " ", MasterRecord.surname).ilike(query_term)
+            concat(MasterRecord.givenname, " ", MasterRecord.surname).like(query_term)
         )
-        conditions.append(MasterRecord.givenname.ilike(query_term))
-        conditions.append(MasterRecord.surname.ilike(query_term))
+        conditions.append(MasterRecord.givenname.like(query_term))
+        conditions.append(MasterRecord.surname.like(query_term))
 
     masterrecords: list[MasterRecord] = (
         session.query(MasterRecord).filter(or_(*conditions)).all()
@@ -242,29 +221,11 @@ def masterrecord_ids_from_dob(
     return matched_ids
 
 
-def masterrecord_ids_from_pidxref_no(session: Session, pid_nos: Iterable[str]):
-    """Finds Ids from pidxref"""
-    # We're searching for PidXRef entries, so we only care about Person.localid
-    # if it's a CLPID (i.e. the ID type corresponding to a PidXRef lookup)
-    query = session.query(Person).filter(Person.localid_type == "CLPID")
-
-    conditions = [Person.localid.like(pid_no) for pid_no in pid_nos]
-    matched_persons: list[Person] = query.filter(or_(*conditions)).all()
-
-    # Find all related master record IDs by recursing through link records
-    related_master_ids, _ = find_related_ids(
-        session, set(), {person.id for person in matched_persons}
-    )
-
-    return related_master_ids
-
-
 def search_masterrecord_ids(  # pylint: disable=too-many-branches
-    nhs_number: list[str],
     mrn_number: list[str],
     ukrdc_number: list[str],
     full_name: list[str],
-    pidx: list[str],
+    pids: list[str],
     dob: list[str],
     search: list[str],
     jtrace: Session,
@@ -274,34 +235,18 @@ def search_masterrecord_ids(  # pylint: disable=too-many-branches
 
     searchset = SearchSet()
 
-    for item in nhs_number:
-        searchset.add_nhs_number(item)
     for item in mrn_number:
         searchset.add_mrn_number(item)
     for item in ukrdc_number:
         searchset.add_ukrdc_number(item)
     for item in full_name:
         searchset.add_name(item)
-    for item in pidx:
+    for item in pids:
         searchset.add_pid(item)
     for item in dob:
         searchset.add_date(item)
 
     searchset.add_terms(search)
-
-    # Check if the search query contains MasterRecord IDs
-    match_sets.append(
-        {
-            record.id
-            for record in (
-                jtrace.query(MasterRecord).get(id_) for id_ in searchset.empi_ids
-            )
-            if record
-        }
-    )
-
-    if searchset.nhs_numbers:
-        match_sets.append(masterrecord_ids_from_nhs_no(jtrace, searchset.nhs_numbers))
 
     if searchset.mrn_numbers:
         match_sets.append(masterrecord_ids_from_mrn_no(jtrace, searchset.mrn_numbers))
@@ -318,7 +263,7 @@ def search_masterrecord_ids(  # pylint: disable=too-many-branches
         match_sets.append(masterrecord_ids_from_dob(jtrace, searchset.dates))
 
     if searchset.pids:
-        match_sets.append(masterrecord_ids_from_pidxref_no(jtrace, searchset.pids))
+        match_sets.append(masterrecord_ids_from_pid(jtrace, searchset.pids))
 
     non_empty_sets: list[set[int]] = [
         match_set for match_set in match_sets if match_set


### PR DESCRIPTION
Removes a couple of unused options for searching, and combined NHS and MRN searching to ensure both UKRDC and NHS/CHI/HSC records are returned when searching by national ID.

Also should enable searching by RADAR number as a byproduct.