### PR TITLE
Return full error objects from "currently failing" list

### DIFF
--- a/ukrdc_fastapi/config.py
+++ b/ukrdc_fastapi/config.py
@@ -32,6 +32,9 @@ class Settings(BaseSettings):
     # Application name used in database connections
     application_name: str = "ukrdc_fastapi"
 
+    # Optionally skip data caching on startup
+    skip_cache: bool = False
+
     # Used to correct linking when behind a reverse proxy
     api_base: str = "/api"
 

--- a/ukrdc_fastapi/main.py
+++ b/ukrdc_fastapi/main.py
@@ -61,12 +61,15 @@ HyperModel.init_app(app)
 
 # Attach event handlers
 
-app.router.add_event_handler("startup", tasks.cache_mirth_channel_info)
-app.router.add_event_handler("startup", tasks.cache_mirth_channel_groups)
-app.router.add_event_handler("startup", tasks.cache_mirth_channel_statistics)
-app.router.add_event_handler("startup", tasks.cache_dash_stats)
-app.router.add_event_handler("startup", tasks.cache_all_facilities)
-app.router.add_event_handler("startup", tasks.cache_all_facilities_history)
+if not settings.skip_cache:
+    app.router.add_event_handler("startup", tasks.cache_mirth_channel_info)
+    app.router.add_event_handler("startup", tasks.cache_mirth_channel_groups)
+    app.router.add_event_handler("startup", tasks.cache_mirth_channel_statistics)
+    app.router.add_event_handler("startup", tasks.cache_dash_stats)
+    app.router.add_event_handler("startup", tasks.cache_all_facilities)
+    app.router.add_event_handler("startup", tasks.cache_all_facilities_history)
+else:
+    logging.warning("Skipping cache startup tasks")
 
 
 class StartupError(RuntimeError):

--- a/ukrdc_fastapi/query/facilities.py
+++ b/ukrdc_fastapi/query/facilities.py
@@ -72,7 +72,7 @@ def _get_message_sumary(
     Generate a summary of message success and errors for a facility.
     """
     query = (
-        errorsdb.query(Message.ni, Message.received, Message.msg_status)
+        errorsdb.query(Message)
         .filter(Message.facility == facility)
         .filter(Message.ni.isnot(None))
         .order_by(Message.ni, Message.received.desc())
@@ -80,13 +80,15 @@ def _get_message_sumary(
     )
 
     all_nis = query.all()
-    err_nis = [m.ni for m in all_nis if m.ni and m.msg_status == "ERROR"]
+    error_nis_messages = [m for m in all_nis if m.ni and m.msg_status == "ERROR"]
+
+    print(f"Done caching {facility}")
 
     return FacilityMessageSummarySchema(
         total_IDs_count=len(all_nis),
-        success_IDs_count=len(all_nis) - len(err_nis),
-        error_IDs_count=len(err_nis),
-        error_IDs=err_nis,
+        success_IDs_count=len(all_nis) - len(error_nis_messages),
+        error_IDs_count=len(error_nis_messages),
+        error_IDs_messages=error_nis_messages,
     )
 
 

--- a/ukrdc_fastapi/routers/api/v1/facilities.py
+++ b/ukrdc_fastapi/routers/api/v1/facilities.py
@@ -35,7 +35,7 @@ def facility(
     redis: Redis = Depends(get_redis),
     user: UKRDCUser = Security(auth.get_user()),
 ):
-    """Retreive a list of on-record facilities"""
+    """Retreive information and current status of a particular facility"""
     return get_facility(ukrdc3, redis, code, user)
 
 
@@ -48,5 +48,5 @@ def facility_errrors_history(
     redis: Redis = Depends(get_redis),
     user: UKRDCUser = Security(auth.get_user()),
 ):
-    """Retreive a list of on-record facilities"""
+    """Retreive time-series new error counts for the last year for a particular facility"""
     return get_errors_history(ukrdc3, redis, code, user, since=since, until=until)

--- a/ukrdc_fastapi/schemas/facility.py
+++ b/ukrdc_fastapi/schemas/facility.py
@@ -2,6 +2,8 @@ from typing import Optional
 
 from fastapi_hypermodel import LinkSet, UrlFor
 
+from ukrdc_fastapi.schemas.message import MessageSchema
+
 from .base import OrmModel
 
 
@@ -9,7 +11,8 @@ class FacilityMessageSummarySchema(OrmModel):
     total_IDs_count: Optional[int] = None
     success_IDs_count: Optional[int] = None
     error_IDs_count: Optional[int] = None
-    error_IDs: Optional[list[str]] = None
+
+    error_IDs_messages: Optional[list[MessageSchema]] = None
 
     @classmethod
     def empty(cls):


### PR DESCRIPTION
Instead of just returning the NIs of currently failing records, we return the entire most recent error object.