### PR TITLE
Reduced messages audit

### DIFF
--- a/tests/test_audit/test_audit_facilities.py
+++ b/tests/test_audit/test_audit_facilities.py
@@ -1,0 +1,24 @@
+from ukrdc_fastapi.models.audit import AuditEvent
+
+
+def test_facility_messages(client, audit_session):
+    response = client.get(
+        "/api/v1/facilities/TEST_SENDING_FACILITY_1/patients_latest_errors/"
+    )
+    assert response.status_code == 200
+
+    events = audit_session.query(AuditEvent).all()
+    assert len(events) == 2
+
+    event = events[0]
+    assert len(event.children) == 1
+
+    assert event.resource == "FACILITY"
+    assert event.operation == "READ"
+    assert event.resource_id == "TEST_SENDING_FACILITY_1"
+    assert event.parent_id == None
+
+    child_event = event.children[0]
+    assert child_event.resource == "MESSAGES"
+    assert child_event.operation == "READ"
+    assert child_event.parent_id == event.id

--- a/tests/test_audit/test_audit_workitems.py
+++ b/tests/test_audit/test_audit_workitems.py
@@ -133,23 +133,18 @@ def test_workitem_messages(client, audit_session):
     response = client.get("/api/v1/workitems/1/messages")
     assert response.status_code == 200
 
-    errors = [MessageSchema(**item) for item in response.json()["items"]]
-    returned_ids = {error.id for error in errors}
-    assert returned_ids == {1, 3}
-
     events = audit_session.query(AuditEvent).all()
-    assert len(events) == 3
+    assert len(events) == 2
 
     event = events[0]
-    assert len(event.children) == 2
+    assert len(event.children) == 1
 
     assert event.resource == "WORKITEM"
     assert event.operation == "READ"
     assert event.resource_id == "1"
     assert event.parent_id == None
 
-    for child_event in event.children:
-        assert child_event.resource == "MESSAGE"
-        assert child_event.operation == "READ"
-        assert int(child_event.resource_id) in returned_ids
-        assert child_event.parent_id == event.id
+    child_event = event.children[0]
+    assert child_event.resource == "MESSAGES"
+    assert child_event.operation == "READ"
+    assert child_event.parent_id == event.id

--- a/ukrdc_fastapi/dependencies/audit.py
+++ b/ukrdc_fastapi/dependencies/audit.py
@@ -35,6 +35,8 @@ class Resource(Enum):
     MESSAGE = "MESSAGE"
     WORKITEM = "WORKITEM"
 
+    FACILITY = "FACILITY"
+
 
 class MasterRecordResource(Enum):
     MESSAGE = "MESSAGE"

--- a/ukrdc_fastapi/routers/api/v1/masterrecords/record_id.py
+++ b/ukrdc_fastapi/routers/api/v1/masterrecords/record_id.py
@@ -237,29 +237,18 @@ def master_record_messages(
     jtrace: Session = Depends(get_jtrace),
     errorsdb: Session = Depends(get_errorsdb),
     sorter: SQLASorter = Depends(ERROR_SORTER),
-    audit: Auditer = Depends(get_auditer),
 ):
     """
     Retreive a list of errors related to a particular master record.
     By default returns message created within the last 365 days.
     """
-    page = paginate(
+    return paginate(
         sorter.sort(
             get_messages_related_to_masterrecord(
                 errorsdb, jtrace, record_id, user, status, facility, since, until
             )
         )
     )
-
-    record_audit = audit.add_event(
-        Resource.MASTER_RECORD, record_id, AuditOperation.READ
-    )
-    for item in page.items:  # type: ignore
-        audit.add_event(
-            Resource.MESSAGE, item.id, AuditOperation.READ, parent=record_audit
-        )
-
-    return page
 
 
 @router.get(

--- a/ukrdc_fastapi/routers/api/v1/masterrecords/record_id.py
+++ b/ukrdc_fastapi/routers/api/v1/masterrecords/record_id.py
@@ -237,11 +237,18 @@ def master_record_messages(
     jtrace: Session = Depends(get_jtrace),
     errorsdb: Session = Depends(get_errorsdb),
     sorter: SQLASorter = Depends(ERROR_SORTER),
+    audit: Auditer = Depends(get_auditer),
 ):
     """
     Retreive a list of errors related to a particular master record.
     By default returns message created within the last 365 days.
     """
+    audit.add_event(
+        Resource.MESSAGES,
+        None,
+        AuditOperation.READ,
+        parent=audit.add_event(Resource.MASTER_RECORD, record_id, AuditOperation.READ),
+    )
     return paginate(
         sorter.sort(
             get_messages_related_to_masterrecord(

--- a/ukrdc_fastapi/routers/api/v1/workitems/workitem_id.py
+++ b/ukrdc_fastapi/routers/api/v1/workitems/workitem_id.py
@@ -153,6 +153,7 @@ def workitem_messages(
     user: UKRDCUser = Security(auth.get_user()),
     jtrace: Session = Depends(get_jtrace),
     errorsdb: Session = Depends(get_errorsdb),
+    audit: Auditer = Depends(get_auditer),
 ):
     """Retreive a list of other work items related to a particular work item"""
     workitem = get_extended_workitem(jtrace, workitem_id, user)
@@ -163,6 +164,13 @@ def workitem_messages(
 
     if workitem.master_record:
         workitem_nis.append(workitem.master_record.nationalid)
+
+    audit.add_event(
+        Resource.MESSAGES,
+        None,
+        AuditOperation.READ,
+        parent=audit.add_event(Resource.WORKITEM, workitem_id, AuditOperation.READ),
+    )
 
     return paginate(
         get_messages(

--- a/ukrdc_fastapi/routers/api/v1/workitems/workitem_id.py
+++ b/ukrdc_fastapi/routers/api/v1/workitems/workitem_id.py
@@ -153,7 +153,6 @@ def workitem_messages(
     user: UKRDCUser = Security(auth.get_user()),
     jtrace: Session = Depends(get_jtrace),
     errorsdb: Session = Depends(get_errorsdb),
-    audit: Auditer = Depends(get_auditer),
 ):
     """Retreive a list of other work items related to a particular work item"""
     workitem = get_extended_workitem(jtrace, workitem_id, user)
@@ -165,7 +164,7 @@ def workitem_messages(
     if workitem.master_record:
         workitem_nis.append(workitem.master_record.nationalid)
 
-    page = paginate(
+    return paginate(
         get_messages(
             errorsdb,
             user,
@@ -176,16 +175,6 @@ def workitem_messages(
             until=until,
         )
     )
-
-    workitem_audit = audit.add_event(
-        Resource.WORKITEM, workitem.id, AuditOperation.READ
-    )
-    for item in page.items:  # type: ignore
-        audit.add_event(
-            Resource.MESSAGE, item.id, AuditOperation.READ, parent=workitem_audit
-        )
-
-    return page
 
 
 @router.post(


### PR DESCRIPTION
Removes auditing individual messages when a list is accessed, instead recording a general MESSAGES audit operation.

Message resources do not contain identifiable information, however we continue to audit message list access for the purposes of auditing access to any resource intended to be restricted to specific users.

Accessing message source XML continues to be audited as before.