### PR TITLE
Multiple UKRDC ID query viewer

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,12 @@ from ukrdc_sqla.errorsdb import Channel
 from ukrdc_sqla.errorsdb import Message as ErrorMessage
 from ukrdc_sqla.pkb import PKBLink
 from ukrdc_sqla.stats import Base as StatsBase
-from ukrdc_sqla.stats import ErrorHistory, FacilityStats, PatientsLatestErrors
+from ukrdc_sqla.stats import (
+    ErrorHistory,
+    FacilityStats,
+    MultipleUKRDCID,
+    PatientsLatestErrors,
+)
 from ukrdc_sqla.ukrdc import Base as UKRDC3Base
 from ukrdc_sqla.ukrdc import (
     Code,
@@ -82,6 +87,22 @@ UKRDCID_1 = "999999999"
 UKRDCID_2 = "999999911"
 UKRDCID_3 = "999999922"
 UKRDCID_4 = "999999933"
+
+
+def populate_basic_stats(statsdb):
+    row_1 = MultipleUKRDCID(
+        group_id=1,
+        master_id=1,
+        last_updated=datetime(2021, 12, 22),
+    )
+    row_2 = MultipleUKRDCID(
+        group_id=1,
+        master_id=4,
+        last_updated=datetime(2021, 12, 22),
+    )
+    statsdb.add(row_1)
+    statsdb.add(row_2)
+    statsdb.commit()
 
 
 def populate_facilities(ukrdc3, statsdb, errorsdb):
@@ -671,6 +692,8 @@ def populate_all(ukrdc3: Session, jtrace: Session, errorsdb: Session, statsdb: S
     populate_patient_2_extra(ukrdc3)
 
     populate_workitems(jtrace)
+
+    populate_basic_stats(statsdb)
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_query/test_masterrecords.py
+++ b/tests/test_query/test_masterrecords.py
@@ -1,7 +1,4 @@
-from datetime import datetime
-
 import pytest
-from ukrdc_sqla.empi import LinkRecord, MasterRecord
 
 from ukrdc_fastapi.query import masterrecords
 from ukrdc_fastapi.query.common import PermissionsError

--- a/tests/test_query/test_stats.py
+++ b/tests/test_query/test_stats.py
@@ -1,6 +1,6 @@
 from datetime import date
 
-from ukrdc_sqla.stats import ErrorHistory, MultipleUKRDCID
+from ukrdc_sqla.stats import ErrorHistory
 
 from ukrdc_fastapi.query.stats import get_full_errors_history, get_multiple_ukrdcids
 
@@ -25,22 +25,6 @@ def test_get_full_errors_history(stats_session):
 
 
 def test_get_multiple_ukrdcids(stats_session, jtrace_session, superuser):
-    # Add multiple UKRDCID rows
-
-    row_1 = MultipleUKRDCID(
-        group_id=1,
-        master_id=1,
-        last_updated=date(2021, 12, 22),
-    )
-    row_2 = MultipleUKRDCID(
-        group_id=1,
-        master_id=4,
-        last_updated=date(2021, 12, 22),
-    )
-    stats_session.add(row_1)
-    stats_session.add(row_2)
-    stats_session.commit()
-
     multiple_id_groups = get_multiple_ukrdcids(stats_session, jtrace_session)
     assert len(multiple_id_groups) == 1
     assert len(multiple_id_groups[0]) == 2

--- a/tests/test_query/test_stats.py
+++ b/tests/test_query/test_stats.py
@@ -1,11 +1,11 @@
 from datetime import date
 
-from ukrdc_sqla.stats import ErrorHistory
+from ukrdc_sqla.stats import ErrorHistory, MultipleUKRDCID
 
-from ukrdc_fastapi.query.stats import get_full_errors_history
+from ukrdc_fastapi.query.stats import get_full_errors_history, get_multiple_ukrdcids
 
 
-def test_get_full_errors_history(stats_session, superuser):
+def test_get_full_errors_history(stats_session):
     history_test_1 = ErrorHistory(
         facility="TEST_SENDING_FACILITY_99", date=date(2021, 1, 1), count=1
     )
@@ -22,3 +22,26 @@ def test_get_full_errors_history(stats_session, superuser):
     d = {point.time: point.count for point in history}
     assert d[date(2021, 1, 1)] == 2
     assert d[date(2021, 1, 2)] == 1
+
+
+def test_get_multiple_ukrdcids(stats_session, jtrace_session, superuser):
+    # Add multiple UKRDCID rows
+
+    row_1 = MultipleUKRDCID(
+        group_id=1,
+        master_id=1,
+        last_updated=date(2021, 12, 22),
+    )
+    row_2 = MultipleUKRDCID(
+        group_id=1,
+        master_id=4,
+        last_updated=date(2021, 12, 22),
+    )
+    stats_session.add(row_1)
+    stats_session.add(row_2)
+    stats_session.commit()
+
+    multiple_id_groups = get_multiple_ukrdcids(stats_session, jtrace_session)
+    assert len(multiple_id_groups) == 1
+    assert len(multiple_id_groups[0]) == 2
+    assert {record.id for record in multiple_id_groups[0]} == {1, 4}

--- a/tests/test_routers/test_admin.py
+++ b/tests/test_routers/test_admin.py
@@ -1,0 +1,10 @@
+def test_datahealth_multiple_ukrdcids(client):
+    # Check expected links
+
+    response = client.get("/api/v1/admin/datahealth/multiple_ukrdcids")
+    assert response.status_code == 200
+
+    multiple_id_groups = response.json().get("items")
+    assert len(multiple_id_groups) == 1
+    assert len(multiple_id_groups[0]) == 2
+    assert {record.get("id") for record in multiple_id_groups[0]} == {1, 4}

--- a/ukrdc_fastapi/query/stats.py
+++ b/ukrdc_fastapi/query/stats.py
@@ -6,7 +6,6 @@ from ukrdc_sqla.empi import MasterRecord
 from ukrdc_sqla.stats import ErrorHistory, MultipleUKRDCID
 
 from ukrdc_fastapi.query.facilities import HistoryPoint
-from ukrdc_fastapi.schemas.empi import MasterRecordSchema
 
 
 def get_full_errors_history(
@@ -54,11 +53,24 @@ def get_full_errors_history(
 def get_multiple_ukrdcids(
     statsdb: Session, jtrace: Session
 ) -> list[list[MasterRecord]]:
+    """
+    Fetch groups of records corresponding to multiple UKRDC IDs for a single patient.
+    Returns a list of lists of records, where the inner lists are groups of records.
+
+    Args:
+        statsdb (Session): Stats database session.
+        jtrace (Session): JTrace database session.
+
+    Returns:
+        list[list[MasterRecord]]: List of groups of records.
+    """
     # Fetch all unresolved rows
     record_groups = {
         item.master_id: item.group_id
         for item in statsdb.query(MultipleUKRDCID).filter(
-            MultipleUKRDCID.resolved == False
+            # pylint: disable=singleton-comparison
+            MultipleUKRDCID.resolved
+            == False
         )
     }
 
@@ -66,7 +78,7 @@ def get_multiple_ukrdcids(
     # This is another case of sacrificing memory for speed. We assume
     # that the number of records is small enough to fit in memory, meaning
     # that we can avoid many small JTRACE queries.
-    records = {
+    records: dict[int, MasterRecord] = {
         record.id: record
         for record in jtrace.query(MasterRecord).filter(
             MasterRecord.id.in_(record_groups.keys())
@@ -74,12 +86,13 @@ def get_multiple_ukrdcids(
     }
 
     # Sort each fetched MasterRecord into groups
-    item_groups = {}
+    item_groups: dict[int, list[MasterRecord]] = {}
     for master_id, group_id in record_groups.items():
         record = records.get(master_id)
-        if group_id in item_groups:
-            item_groups[group_id].append(record)
-        else:
-            item_groups[group_id] = [record]
+        if record:
+            if group_id in item_groups:
+                item_groups[group_id].append(record)
+            else:
+                item_groups[group_id] = [record]
 
     return list(item_groups.values())

--- a/ukrdc_fastapi/query/stats.py
+++ b/ukrdc_fastapi/query/stats.py
@@ -2,9 +2,11 @@ import datetime
 from typing import Optional
 
 from sqlalchemy.orm.session import Session
-from ukrdc_sqla.stats import ErrorHistory
+from ukrdc_sqla.empi import MasterRecord
+from ukrdc_sqla.stats import ErrorHistory, MultipleUKRDCID
 
 from ukrdc_fastapi.query.facilities import HistoryPoint
+from ukrdc_fastapi.schemas.empi import MasterRecordSchema
 
 
 def get_full_errors_history(
@@ -47,3 +49,37 @@ def get_full_errors_history(
     points.sort(key=lambda p: p.time)
 
     return points
+
+
+def get_multiple_ukrdcids(
+    statsdb: Session, jtrace: Session
+) -> list[list[MasterRecord]]:
+    # Fetch all unresolved rows
+    record_groups = {
+        item.master_id: item.group_id
+        for item in statsdb.query(MultipleUKRDCID).filter(
+            MultipleUKRDCID.resolved == False
+        )
+    }
+
+    # Fetch MasterRecord objects for each row, and key with record ID
+    # This is another case of sacrificing memory for speed. We assume
+    # that the number of records is small enough to fit in memory, meaning
+    # that we can avoid many small JTRACE queries.
+    records = {
+        record.id: record
+        for record in jtrace.query(MasterRecord).filter(
+            MasterRecord.id.in_(record_groups.keys())
+        )
+    }
+
+    # Sort each fetched MasterRecord into groups
+    item_groups = {}
+    for master_id, group_id in record_groups.items():
+        record = records.get(master_id)
+        if group_id in item_groups:
+            item_groups[group_id].append(record)
+        else:
+            item_groups[group_id] = [record]
+
+    return list(item_groups.values())

--- a/ukrdc_fastapi/routers/api/v1/admin.py
+++ b/ukrdc_fastapi/routers/api/v1/admin.py
@@ -8,10 +8,12 @@ from ukrdc_sqla.stats import PatientsLatestErrors
 
 from ukrdc_fastapi.dependencies import get_jtrace, get_statsdb
 from ukrdc_fastapi.dependencies.auth import Permissions, UKRDCUser, auth
-from ukrdc_fastapi.query.stats import get_full_errors_history
+from ukrdc_fastapi.query.stats import get_full_errors_history, get_multiple_ukrdcids
 from ukrdc_fastapi.query.workitems import get_full_workitem_history, get_workitems
 from ukrdc_fastapi.schemas.admin import AdminCountsSchema
 from ukrdc_fastapi.schemas.common import HistoryPoint
+from ukrdc_fastapi.schemas.empi import MasterRecordSchema
+from ukrdc_fastapi.utils.paginate import Page, paginate_sequence
 
 router = APIRouter(tags=["Admin"])
 
@@ -99,3 +101,28 @@ def admin_counts(
         UKRDC_records=ukrdc_records_count,
         patients_receiving_errors=patients_receiving_errors_count,
     )
+
+
+# Data health reports
+
+
+@router.get(
+    "/datahealth/multiple_ukrdcids",
+    response_model=Page[list[MasterRecordSchema]],
+    dependencies=[
+        Security(
+            auth.permission(
+                [
+                    Permissions.READ_RECORDS,
+                    Permissions.UNIT_PREFIX + Permissions.UNIT_WILDCARD,
+                ]
+            )
+        )
+    ],
+)
+def datahealth_multiple_ukrdcids(
+    jtrace: Session = Depends(get_jtrace),
+    statsdb: Session = Depends(get_statsdb),
+):
+    """Retreive list of patients with multiple UKRDC IDs"""
+    return paginate_sequence(get_multiple_ukrdcids(statsdb, jtrace))

--- a/ukrdc_fastapi/utils/paginate.py
+++ b/ukrdc_fastapi/utils/paginate.py
@@ -1,11 +1,12 @@
 from typing import Generic, TypeVar
 
 from fastapi import Query
+from fastapi_pagination import paginate as paginate_sequence
 from fastapi_pagination.default import Page as BasePage
 from fastapi_pagination.default import Params as BaseParams
 from fastapi_pagination.ext.sqlalchemy import paginate, paginate_query
 
-__all__ = ["Page", "paginate", "paginate_query"]
+__all__ = ["Page", "Params", "paginate", "paginate_sequence", "paginate_query"]
 
 T = TypeVar("T")  # pylint: disable=invalid-name
 


### PR DESCRIPTION
Adds an API route to view the stats database query for patients with multiple UKRDC IDs.

## Todo

- [x] Unit tests