### PR TITLE
Restrict record exporting to non-NHSBT data feeds

### DIFF
--- a/tests/test_query/test_mirth/test_export.py
+++ b/tests/test_query/test_mirth/test_export.py
@@ -1,11 +1,9 @@
-import pytest
 from ukrdc_sqla.ukrdc import ProgramMembership
 
 from tests.utils import days_ago
 from ukrdc_fastapi.query.mirth import export
 
 
-@pytest.mark.asyncio
 async def test_export_all_to_pv(
     ukrdc3_session, redis_session, mirth_session, superuser
 ):

--- a/tests/test_query/test_mirth/test_export_restrictions.py
+++ b/tests/test_query/test_mirth/test_export_restrictions.py
@@ -1,0 +1,68 @@
+from datetime import datetime
+
+import pytest
+
+from ukrdc_fastapi.exceptions import RecordTypeError
+from ukrdc_fastapi.query.mirth import export
+
+from ...utils import create_basic_facility, create_basic_patient
+
+TEST_ID = 100000000
+
+
+def _commit_test_patient(ukrdc3, jtrace, sending_facility: str, sending_extract: str):
+    """
+    Quickly create and commit a new patientrecord with a given sending facility and extract
+    """
+    create_basic_facility(
+        sending_facility,
+        f"{sending_facility}_DESCRIPTION",
+        ukrdc3,
+    )
+    create_basic_patient(
+        TEST_ID,  # ID
+        str(TEST_ID),  # PID
+        str(TEST_ID),  # UKRDC
+        "9434765870",  # NHS
+        sending_facility,
+        sending_extract,
+        f"PYTEST:EXPORT:{TEST_ID}",
+        "SURNAME_EXPORT",
+        "NAME_EXPORT",
+        datetime(1950, 1, 1),
+        ukrdc3,
+        jtrace,
+    )
+
+
+@pytest.mark.parametrize(
+    "sending_facility,sending_extract",
+    [
+        ("NHSBT", "SENDING_EXTRACT"),
+        ("PV", "UKRDC"),
+        ("PKB", "UKRDC"),
+        ("UKRR", "SENDING_EXTRACT"),
+        ("SENDING_FACILITY", "RADAR"),
+        ("TRACING", "UKRDC"),
+        ("SENDING_FACILITY", "PVMIG"),
+        ("SENDING_FACILITY", "HSMIG"),
+        ("SENDING_FACILITY", "SURVEY"),
+    ],
+)
+async def test_export_all_to_pv_forbidden(
+    ukrdc3_session,
+    jtrace_session,
+    redis_session,
+    mirth_session,
+    superuser,
+    sending_facility,
+    sending_extract,
+):
+    _commit_test_patient(
+        ukrdc3_session, jtrace_session, sending_facility, sending_extract
+    )
+
+    with pytest.raises(RecordTypeError):
+        await export.export_all_to_pv(
+            str(TEST_ID), superuser, ukrdc3_session, mirth_session, redis_session
+        )

--- a/tests/test_query/test_mirth/test_export_restrictions.py
+++ b/tests/test_query/test_mirth/test_export_restrictions.py
@@ -9,6 +9,19 @@ from ...utils import create_basic_facility, create_basic_patient
 
 TEST_ID = 100000000
 
+# SendingFacility/SendingExtract combinations that should cause any export to fail
+FAIL_SF_SE = [
+    ("NHSBT", "SENDING_EXTRACT"),
+    ("PV", "UKRDC"),
+    ("PKB", "UKRDC"),
+    ("UKRR", "SENDING_EXTRACT"),
+    ("SENDING_FACILITY", "RADAR"),
+    ("TRACING", "UKRDC"),
+    ("SENDING_FACILITY", "PVMIG"),
+    ("SENDING_FACILITY", "HSMIG"),
+    ("SENDING_FACILITY", "SURVEY"),
+]
+
 
 def _commit_test_patient(ukrdc3, jtrace, sending_facility: str, sending_extract: str):
     """
@@ -35,20 +48,7 @@ def _commit_test_patient(ukrdc3, jtrace, sending_facility: str, sending_extract:
     )
 
 
-@pytest.mark.parametrize(
-    "sending_facility,sending_extract",
-    [
-        ("NHSBT", "SENDING_EXTRACT"),
-        ("PV", "UKRDC"),
-        ("PKB", "UKRDC"),
-        ("UKRR", "SENDING_EXTRACT"),
-        ("SENDING_FACILITY", "RADAR"),
-        ("TRACING", "UKRDC"),
-        ("SENDING_FACILITY", "PVMIG"),
-        ("SENDING_FACILITY", "HSMIG"),
-        ("SENDING_FACILITY", "SURVEY"),
-    ],
-)
+@pytest.mark.parametrize("sending_facility,sending_extract", FAIL_SF_SE)
 async def test_export_all_to_pv_forbidden(
     ukrdc3_session,
     jtrace_session,
@@ -64,5 +64,85 @@ async def test_export_all_to_pv_forbidden(
 
     with pytest.raises(RecordTypeError):
         await export.export_all_to_pv(
+            str(TEST_ID), superuser, ukrdc3_session, mirth_session, redis_session
+        )
+
+
+@pytest.mark.parametrize("sending_facility,sending_extract", FAIL_SF_SE)
+async def test_record_export_tests_forbidden(
+    ukrdc3_session,
+    jtrace_session,
+    redis_session,
+    mirth_session,
+    superuser,
+    sending_facility,
+    sending_extract,
+):
+    _commit_test_patient(
+        ukrdc3_session, jtrace_session, sending_facility, sending_extract
+    )
+
+    with pytest.raises(RecordTypeError):
+        await export.export_tests_to_pv(
+            str(TEST_ID), superuser, ukrdc3_session, mirth_session, redis_session
+        )
+
+
+@pytest.mark.parametrize("sending_facility,sending_extract", FAIL_SF_SE)
+async def test_record_export_docs_forbidden(
+    ukrdc3_session,
+    jtrace_session,
+    redis_session,
+    mirth_session,
+    superuser,
+    sending_facility,
+    sending_extract,
+):
+    _commit_test_patient(
+        ukrdc3_session, jtrace_session, sending_facility, sending_extract
+    )
+
+    with pytest.raises(RecordTypeError):
+        await export.export_docs_to_pv(
+            str(TEST_ID), superuser, ukrdc3_session, mirth_session, redis_session
+        )
+
+
+@pytest.mark.parametrize("sending_facility,sending_extract", FAIL_SF_SE)
+async def test_record_export_radar_forbidden(
+    ukrdc3_session,
+    jtrace_session,
+    redis_session,
+    mirth_session,
+    superuser,
+    sending_facility,
+    sending_extract,
+):
+    _commit_test_patient(
+        ukrdc3_session, jtrace_session, sending_facility, sending_extract
+    )
+
+    with pytest.raises(RecordTypeError):
+        await export.export_all_to_radar(
+            str(TEST_ID), superuser, ukrdc3_session, mirth_session, redis_session
+        )
+
+
+@pytest.mark.parametrize("sending_facility,sending_extract", FAIL_SF_SE)
+async def test_record_export_pkb_forbidden(
+    ukrdc3_session,
+    jtrace_session,
+    redis_session,
+    mirth_session,
+    superuser,
+    sending_facility,
+    sending_extract,
+):
+    _commit_test_patient(
+        ukrdc3_session, jtrace_session, sending_facility, sending_extract
+    )
+
+    with pytest.raises(RecordTypeError):
+        await export.export_all_to_pkb(
             str(TEST_ID), superuser, ukrdc3_session, mirth_session, redis_session
         )

--- a/ukrdc_fastapi/utils/mirth/messages/pkb.py
+++ b/ukrdc_fastapi/utils/mirth/messages/pkb.py
@@ -181,8 +181,6 @@ def build_pkb_sync_messages(record: PatientRecord, ukrdc3: Session) -> list[str]
     Returns:
         list[str]: XML rawData for Mirth messages
     """
-    # TODO: Check user permissions for record/record.sending_facility (likely upstream check)
-
     # Check memberships
 
     if not record_has_active_membership(ukrdc3, record, "PKB"):

--- a/ukrdc_fastapi/utils/records.py
+++ b/ukrdc_fastapi/utils/records.py
@@ -1,0 +1,47 @@
+from ukrdc_sqla.ukrdc import PatientRecord
+
+MIGRATED_EXTRACTS = ("PVMIG", "HSMIG")
+UKRDC_MEMBERSHIP_FACILITIES = ("PV", "PKB")
+
+
+def record_is_survey(record: PatientRecord):
+    """All SURVEY extracts are survey records"""
+    return record.sendingextract == "SURVEY"
+
+
+def record_is_migrated(record: PatientRecord):
+    """All *MIG extracts are migrated records"""
+    return record.sendingextract in MIGRATED_EXTRACTS
+
+
+def record_is_tracing(record: PatientRecord):
+    """All TRACING facilities are tracing records"""
+    return record.sendingfacility == "TRACING"
+
+
+def record_is_membership(record: PatientRecord):
+    """Check if a record is a membership record"""
+
+    # All RADAR extracts are membership records
+    if record.sendingextract == "RADAR":
+        return True
+    # All UKRR facilities are membership records
+    if record.sendingfacility == "UKRR":
+        return True
+    # UKRDC extracts are only memberships if they are from certain facilities
+    if (
+        record.sendingextract == "UKRDC"
+        and record.sendingfacility in UKRDC_MEMBERSHIP_FACILITIES
+    ):
+        return True
+    return False
+
+
+def record_is_data(record: PatientRecord):
+    """Everything else is a data record"""
+    return not (
+        record_is_survey(record)
+        or record_is_migrated(record)
+        or record_is_tracing(record)
+        or record_is_membership(record)
+    )


### PR DESCRIPTION
Should resolve https://renalregistry.atlassian.net/browse/UI-179 by blocking invalid exports at the API level.

UI-level restrictions are already in place, but have been corrected by https://github.com/renalreg/ukrdc-nuxt/pull/148