### PR TITLE
Zero-populated histories

### DIFF
--- a/tests/test_query/test_facilities.py
+++ b/tests/test_query/test_facilities.py
@@ -87,9 +87,9 @@ def test_get_facility_history(ukrdc3_session, stats_session, superuser):
         test_code.code,
         superuser,
     )
-    assert len(history) == 1
-    assert history[0].time == days_ago(1).date()
-    assert history[0].count == 1
+    assert len(history) == 365
+    assert history[-1].time == days_ago(1).date()
+    assert history[-1].count == 1
 
 
 def test_get_facility_history_range(ukrdc3_session, stats_session, superuser):
@@ -113,7 +113,7 @@ def test_get_facility_history_range(ukrdc3_session, stats_session, superuser):
         superuser,
         until=days_ago(5),
     )
-    assert len(history) == 0
+    assert len(history) == 360
 
     history = get_errors_history(
         ukrdc3_session,
@@ -123,7 +123,7 @@ def test_get_facility_history_range(ukrdc3_session, stats_session, superuser):
         since=days_ago(5),
         until=days_ago(0),
     )
-    assert len(history) == 1
+    assert len(history) == 5
 
 
 def test_get_facility_history_denied(ukrdc3_session, stats_session, test_user):

--- a/tests/test_routers/test_facilities.py
+++ b/tests/test_routers/test_facilities.py
@@ -28,8 +28,8 @@ async def test_facility_error_history(client):
         f"{configuration.base_url}/v1/facilities/TEST_SENDING_FACILITY_1/error_history"
     )
     json = response.json()
-    assert len(json) == 1
-    assert json[0].get("time") == days_ago(1).date().isoformat()
+    assert len(json) == 365
+    assert json[-1].get("time") == days_ago(1).date().isoformat()
 
 
 async def test_facility_patients_latest_errors(client):

--- a/ukrdc_fastapi/query/facilities/errors.py
+++ b/ukrdc_fastapi/query/facilities/errors.py
@@ -93,27 +93,27 @@ def get_errors_history(
         raise PermissionsError()
 
     # Get range
-    rangeSince: datetime.date = since or datetime.date.today() - datetime.timedelta(
+    range_since: datetime.date = since or datetime.date.today() - datetime.timedelta(
         days=365
     )
-    rangeUntil: datetime.date = until or datetime.date.today()
+    range_until: datetime.date = until or datetime.date.today()
 
     # Get history within range
     history = (
         statsdb.query(ErrorHistory)
         .filter(ErrorHistory.facility == facility_code)
-        .filter(ErrorHistory.date >= rangeSince)
-        .filter(ErrorHistory.date <= rangeUntil)
+        .filter(ErrorHistory.date >= range_since)
+        .filter(ErrorHistory.date <= range_until)
     )
 
     # Create an initially empty full history dictionary
     full_history: dict[datetime.date, int] = {
-        date: 0 for date in daterange(rangeSince, rangeUntil)
+        date: 0 for date in daterange(range_since, range_until)
     }
 
     # For each non-zero history point, add it to the full history
     for history_point in history:
-        full_history[history_point.date] = history_point.count
+        full_history[history_point.date] = history_point.count or 0
 
     points = [
         HistoryPoint(time=date, count=count) for date, count in full_history.items()

--- a/ukrdc_fastapi/query/stats.py
+++ b/ukrdc_fastapi/query/stats.py
@@ -27,21 +27,21 @@ def get_full_errors_history(
     """
 
     # Get range
-    rangeSince: datetime.date = since or datetime.date.today() - datetime.timedelta(
+    range_since: datetime.date = since or datetime.date.today() - datetime.timedelta(
         days=365
     )
-    rangeUntil: datetime.date = until or datetime.date.today()
+    range_until: datetime.date = until or datetime.date.today()
 
     # Get history within range
     history = (
         statsdb.query(ErrorHistory)
-        .filter(ErrorHistory.date >= rangeSince)
-        .filter(ErrorHistory.date <= rangeUntil)
+        .filter(ErrorHistory.date >= range_since)
+        .filter(ErrorHistory.date <= range_until)
     )
 
     # Create an initially empty full history dictionary
     combined_history: dict[datetime.date, int] = {
-        date: 0 for date in daterange(rangeSince, rangeUntil)
+        date: 0 for date in daterange(range_since, range_until)
     }
 
     # For each non-zero history point, add it to the full history

--- a/ukrdc_fastapi/query/workitems.py
+++ b/ukrdc_fastapi/query/workitems.py
@@ -16,6 +16,7 @@ from ukrdc_fastapi.query.messages import get_message
 from ukrdc_fastapi.query.persons import get_persons_related_to_masterrecord
 from ukrdc_fastapi.schemas.common import HistoryPoint
 from ukrdc_fastapi.schemas.empi import WorkItemExtendedSchema
+from ukrdc_fastapi.utils import daterange
 
 
 def _apply_query_permissions(query: Query, user: UKRDCUser):
@@ -271,26 +272,35 @@ def get_full_workitem_history(
     Returns:
         list[HistoryPoint]: Error history points.
     """
+
+    # Get range
+    rangeSince: datetime.date = since or datetime.date.today() - datetime.timedelta(
+        days=365
+    )
+    rangeUntil: datetime.date = until or datetime.date.today()
+
+    # Get history within range
     trunc_func = func.date_trunc("day", WorkItem.creation_date)
     history = (
         jtrace.query(trunc_func, func.count(trunc_func))
-        .filter(
-            trunc_func
-            >= (since or (datetime.datetime.utcnow() - datetime.timedelta(days=365)))
-        )
+        .filter(trunc_func >= rangeSince)
+        .filter(trunc_func <= rangeUntil)
         .group_by(trunc_func)
         .order_by(trunc_func)
     )
 
-    if until:
-        history = history.filter(trunc_func <= until)
+    # Create an initially empty full history dictionary
+    full_history: dict[datetime.date, int] = {
+        date: 0 for date in daterange(rangeSince, rangeUntil)
+    }
+
+    # For each non-zero history point, add it to the full history
+    for history_point in history:
+        full_history[history_point[0]] = history_point[-1]
 
     points = [
-        HistoryPoint(
-            time=point[0],
-            count=point[-1],
-        )
-        for point in history.all()
+        HistoryPoint(time=date, count=count) for date, count in full_history.items()
     ]
+    points.sort(key=lambda p: p.time)
 
     return points

--- a/ukrdc_fastapi/query/workitems.py
+++ b/ukrdc_fastapi/query/workitems.py
@@ -274,24 +274,24 @@ def get_full_workitem_history(
     """
 
     # Get range
-    rangeSince: datetime.date = since or datetime.date.today() - datetime.timedelta(
+    range_since: datetime.date = since or datetime.date.today() - datetime.timedelta(
         days=365
     )
-    rangeUntil: datetime.date = until or datetime.date.today()
+    range_until: datetime.date = until or datetime.date.today()
 
     # Get history within range
     trunc_func = func.date_trunc("day", WorkItem.creation_date)
     history = (
         jtrace.query(trunc_func, func.count(trunc_func))
-        .filter(trunc_func >= rangeSince)
-        .filter(trunc_func <= rangeUntil)
+        .filter(trunc_func >= range_since)
+        .filter(trunc_func <= range_until)
         .group_by(trunc_func)
         .order_by(trunc_func)
     )
 
     # Create an initially empty full history dictionary
     full_history: dict[datetime.date, int] = {
-        date: 0 for date in daterange(rangeSince, rangeUntil)
+        date: 0 for date in daterange(range_since, range_until)
     }
 
     # For each non-zero history point, add it to the full history

--- a/ukrdc_fastapi/utils/__init__.py
+++ b/ukrdc_fastapi/utils/__init__.py
@@ -1,6 +1,6 @@
 import datetime
 from time import time
-from typing import Generator, Optional
+from typing import Generator, Optional, Union
 
 
 class Timer:
@@ -63,7 +63,8 @@ def parse_date(date_string: Optional[str]) -> Optional[datetime.datetime]:
 
 
 def daterange(
-    start_date: datetime.date, end_date: datetime.date
+    start_date: Union[datetime.date, datetime.datetime],
+    end_date: Union[datetime.date, datetime.datetime],
 ) -> Generator[datetime.date, None, None]:
     """
     Generate a range of dates between two dates, separated by one day
@@ -75,6 +76,12 @@ def daterange(
     Yields:
         datetime.date: Date between start and end
     """
+    # "Round" datetimes to dates
+    if isinstance(start_date, datetime.datetime):
+        start_date = start_date.date()
+    if isinstance(end_date, datetime.datetime):
+        end_date = end_date.date()
+
     # Add one day to end date to include it in the range
-    for n in range(int(((end_date + datetime.timedelta(days=1)) - start_date).days)):
-        yield start_date + datetime.timedelta(n)
+    for day_offset in range(int((end_date - start_date).days)):
+        yield start_date + datetime.timedelta(day_offset)

--- a/ukrdc_fastapi/utils/__init__.py
+++ b/ukrdc_fastapi/utils/__init__.py
@@ -1,6 +1,6 @@
 import datetime
 from time import time
-from typing import Optional
+from typing import Generator, Optional
 
 
 class Timer:
@@ -60,3 +60,21 @@ def parse_date(date_string: Optional[str]) -> Optional[datetime.datetime]:
         except ValueError:
             pass
     return None
+
+
+def daterange(
+    start_date: datetime.date, end_date: datetime.date
+) -> Generator[datetime.date, None, None]:
+    """
+    Generate a range of dates between two dates, separated by one day
+
+    Args:
+        start_date (datetime.date): Start date
+        end_date (datetime.date): End date
+
+    Yields:
+        datetime.date: Date between start and end
+    """
+    # Add one day to end date to include it in the range
+    for n in range(int(((end_date + datetime.timedelta(days=1)) - start_date).days)):
+        yield start_date + datetime.timedelta(n)


### PR DESCRIPTION
Populates all error history responses with zeros for dates with no explicit data.

In our error and workitem histories, any missing date corresponds to a zero-count. We need these zero-counts to be shown in the UI as the data is *not* missing, it literally means zero errors. While we can do that at the client side, it seems more sensible to include the full data in the API.