### PR TITLE
feat: allow filtering search results to a specific set of sendingextracts

### DIFF
--- a/tests/test_routers/test_search/test_search_masterrecords.py
+++ b/tests/test_routers/test_search/test_search_masterrecords.py
@@ -64,21 +64,19 @@ async def test_search_ukrdc_number(ukrdc3_session, jtrace_session, client_superu
         assert returned_ids == {index + BUMPER, index + BUMPER + 100}
 
 
-async def test_search_facility_superuser(
-    ukrdc3_session, jtrace_session, client_superuser
-):
-    # Add extra test items
-    commit_extra_patients(ukrdc3_session, jtrace_session)
+async def test_search_facility_superuser(client_superuser):
+    # Test permissions using the conftest test data
+    url = f"{configuration.base_url}/search?facility=TSF01"
+    response = await client_superuser.get(url)
+    assert response.status_code == 200
+    returned_ids = {item["id"] for item in response.json()["items"]}
+    assert returned_ids == {1, 4, 101, 104}
 
-    # Search for each item individually
-    for index, _ in enumerate(TEST_NUMBERS):
-        url = f"{configuration.base_url}/search?facility=TSF{index + BUMPER}"
-
-        response = await client_superuser.get(url)
-        assert response.status_code == 200
-
-        returned_ids = {item["id"] for item in response.json()["items"]}
-        assert returned_ids == {index + BUMPER, index + BUMPER + 100}
+    url = f"{configuration.base_url}/search?facility=TSF02"
+    response = await client_superuser.get(url)
+    assert response.status_code == 200
+    returned_ids = {item["id"] for item in response.json()["items"]}
+    assert returned_ids == {2, 102}
 
 
 async def test_search_name(ukrdc3_session, jtrace_session, client_superuser):
@@ -148,21 +146,19 @@ async def test_search_implicit_dob(ukrdc3_session, jtrace_session, client_superu
         assert returned_ids == {index + BUMPER, index + BUMPER + 100}
 
 
-async def test_search_implicit_facility(
-    ukrdc3_session, jtrace_session, client_superuser
-):
-    # Add extra test items
-    commit_extra_patients(ukrdc3_session, jtrace_session)
+async def test_search_implicit_facility(client_superuser):
+    # Test permissions using the conftest test data
+    url = f"{configuration.base_url}/search?search=TSF01"
+    response = await client_superuser.get(url)
+    assert response.status_code == 200
+    returned_ids = {item["id"] for item in response.json()["items"]}
+    assert returned_ids == {1, 4, 101, 104}
 
-    # Search for each item individually
-    for index, _ in enumerate(TEST_NUMBERS):
-        url = f"{configuration.base_url}/search?search=TSF{index + BUMPER}"
-
-        response = await client_superuser.get(url)
-        assert response.status_code == 200
-
-        returned_ids = {item["id"] for item in response.json()["items"]}
-        assert returned_ids == {index + BUMPER, index + BUMPER + 100}
+    url = f"{configuration.base_url}/search?search=TSF02"
+    response = await client_superuser.get(url)
+    assert response.status_code == 200
+    returned_ids = {item["id"] for item in response.json()["items"]}
+    assert returned_ids == {2, 102}
 
 
 async def test_search_permissions(client_authenticated):

--- a/tests/test_routers/test_search/test_search_patientrecords.py
+++ b/tests/test_routers/test_search/test_search_patientrecords.py
@@ -17,6 +17,8 @@ async def test_search_all(ukrdc3_session, jtrace_session, client_superuser):
         response = await client_superuser.get(url)
         assert response.status_code == 200
 
+        print(response.json()["items"])
+
         returned_ids = {item["pid"] for item in response.json()["items"]}
         assert returned_ids == {number}
 
@@ -55,7 +57,6 @@ async def test_search_ukrdc_number(ukrdc3_session, jtrace_session, client_superu
     # Add extra test items
     commit_extra_patients(ukrdc3_session, jtrace_session)
 
-    # Search for each item individually
     for index, number in enumerate(TEST_NUMBERS):
         url = (
             f"{configuration.base_url}/search/records?ukrdc_number={100000000 + index}"
@@ -74,16 +75,29 @@ async def test_search_facility_superuser(
     # Add extra test items
     commit_extra_patients(ukrdc3_session, jtrace_session)
 
-    # Search for each item individually
-    for index, number in enumerate(TEST_NUMBERS):
-        url = f"{configuration.base_url}/search/records?facility=TSF{index + BUMPER}"
+    for facility in ["TSF00", "TSF01"]:
+        url = f"{configuration.base_url}/search/records?facility={facility}"
 
         response = await client_superuser.get(url)
         assert response.status_code == 200
 
-        returned_ids = {item["pid"] for item in response.json()["items"]}
-        assert returned_ids == {number}
+        returned_facilities = {item["sendingfacility"] for item in response.json()["items"]}
+        assert returned_facilities == {facility}
 
+async def test_search_extract_superuser(
+    ukrdc3_session, jtrace_session, client_superuser
+):
+    # Add extra test items
+    commit_extra_patients(ukrdc3_session, jtrace_session)
+
+    for i, extract in enumerate(["PV", "UKRDC"]):
+        url = f"{configuration.base_url}/search/records?facility=TSF0{i}&extract={extract}"
+
+        response = await client_superuser.get(url)
+        assert response.status_code == 200
+
+        returned_extracts = {item["sendingextract"] for item in response.json()["items"]}
+        assert returned_extracts == {extract}
 
 async def test_search_name(ukrdc3_session, jtrace_session, client_superuser):
     # Add extra test items
@@ -158,15 +172,14 @@ async def test_search_implicit_facility(
     # Add extra test items
     commit_extra_patients(ukrdc3_session, jtrace_session)
 
-    # Search for each item individually
-    for index, number in enumerate(TEST_NUMBERS):
-        url = f"{configuration.base_url}/search/records?search=TSF{index + BUMPER}"
+    for facility in ["TSF00", "TSF01"]:
+        url = f"{configuration.base_url}/search/records?search={facility}"
 
         response = await client_superuser.get(url)
         assert response.status_code == 200
 
-        returned_ids = {item["pid"] for item in response.json()["items"]}
-        assert returned_ids == {number}
+        returned_facilities = {item["sendingfacility"] for item in response.json()["items"]}
+        assert returned_facilities == {facility}
 
 
 async def test_search_permissions(client_authenticated):

--- a/tests/test_routers/test_search/test_search_patientrecords.py
+++ b/tests/test_routers/test_search/test_search_patientrecords.py
@@ -17,8 +17,6 @@ async def test_search_all(ukrdc3_session, jtrace_session, client_superuser):
         response = await client_superuser.get(url)
         assert response.status_code == 200
 
-        print(response.json()["items"])
-
         returned_ids = {item["pid"] for item in response.json()["items"]}
         assert returned_ids == {number}
 
@@ -75,7 +73,7 @@ async def test_search_facility_superuser(
     # Add extra test items
     commit_extra_patients(ukrdc3_session, jtrace_session)
 
-    for facility in ["TSF00", "TSF01"]:
+    for facility in ["TSF01", "TSF02"]:
         url = f"{configuration.base_url}/search/records?facility={facility}"
 
         response = await client_superuser.get(url)
@@ -91,7 +89,7 @@ async def test_search_extract_superuser(
     commit_extra_patients(ukrdc3_session, jtrace_session)
 
     for i, extract in enumerate(["PV", "UKRDC"]):
-        url = f"{configuration.base_url}/search/records?facility=TSF0{i}&extract={extract}"
+        url = f"{configuration.base_url}/search/records?facility=TSF0{i+1}&extract={extract}"
 
         response = await client_superuser.get(url)
         assert response.status_code == 200
@@ -172,7 +170,7 @@ async def test_search_implicit_facility(
     # Add extra test items
     commit_extra_patients(ukrdc3_session, jtrace_session)
 
-    for facility in ["TSF00", "TSF01"]:
+    for facility in ["TSF01", "TSF02"]:
         url = f"{configuration.base_url}/search/records?search={facility}"
 
         response = await client_superuser.get(url)

--- a/tests/test_routers/test_search/utils.py
+++ b/tests/test_routers/test_search/utils.py
@@ -25,7 +25,7 @@ def commit_extra_patients(ukrdc3, jtrace):
             number,
             str(100000000 + index),
             number,
-            f"TSF0{record_group_no}",
+            f"TSF0{record_group_no + 1}",
             "UKRDC" if record_group_no else "PV",
             str(number),
             f"SURNAME{index}",

--- a/tests/test_routers/test_search/utils.py
+++ b/tests/test_routers/test_search/utils.py
@@ -18,33 +18,19 @@ BUMPER = 200
 
 def commit_extra_patients(ukrdc3, jtrace):
     for index, number in enumerate(TEST_NUMBERS):
-        nhs_number = number
-        ukrdcid = 100000000 + index
-
-        dob = datetime(1950, 1, (index + 11) % 28)
-        localid = str(number)
-
-        sending_facility = f"TSF{index + BUMPER}"
-        sending_facility_desc = f"TSF{index + BUMPER}_DESCRIPTION"
-        sending_extract = "UKRDC"
-
-        create_basic_facility(
-            sending_facility,
-            sending_facility_desc,
-            ukrdc3,
-        )
+        record_group_no = index % 2
 
         create_basic_patient(
             index + BUMPER,
             number,
-            str(ukrdcid),
-            nhs_number,
-            sending_facility,
-            sending_extract,
-            localid,
+            str(100000000 + index),
+            number,
+            f"TSF0{record_group_no}",
+            "UKRDC" if record_group_no else "PV",
+            str(number),
             f"SURNAME{index}",
             f"NAME{index}",
-            dob,
+            datetime(1950, 1, (index + 11) % 28),
             ukrdc3,
             jtrace,
         )

--- a/ukrdc_fastapi/routers/api/search.py
+++ b/ukrdc_fastapi/routers/api/search.py
@@ -107,6 +107,7 @@ def search_records(
     full_name: list[str] = QueryParam([], description="Patient full name"),
     dob: list[str] = QueryParam([], description="Patient date of birth"),
     facility: list[str] = QueryParam([], description="Facility code"),
+    extract: list[str] = QueryParam([], description="Extract code"),
     search: list[str] = QueryParam([], description="Free-text search query"),
     include_migrated: bool = QueryParam(
         False, description="Include migrated records in search results"
@@ -159,6 +160,14 @@ def search_records(
         matched_records = matched_records.filter(
             PatientRecord.sendingfacility.in_(facility)
         )
+
+    # Strict filter by sending extract
+    print(matched_records.all())
+    if extract:
+        matched_records = matched_records.filter(
+            PatientRecord.sendingextract.in_(extract)
+        )
+        print(matched_records.all())
 
     # Apply permissions
     matched_records = apply_patientrecord_list_permission(matched_records, user)

--- a/ukrdc_fastapi/routers/api/search.py
+++ b/ukrdc_fastapi/routers/api/search.py
@@ -162,12 +162,10 @@ def search_records(
         )
 
     # Strict filter by sending extract
-    print(matched_records.all())
     if extract:
         matched_records = matched_records.filter(
             PatientRecord.sendingextract.in_(extract)
         )
-        print(matched_records.all())
 
     # Apply permissions
     matched_records = apply_patientrecord_list_permission(matched_records, user)


### PR DESCRIPTION
Adds a new field to the patient record search API to filter returned results to only those with a specific sending extract. Intended to help with things like only showing records from RDA feeds.