### PR TITLE
chore: migrate to select api

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -935,7 +935,7 @@ files = [
 name = "mypy"
 version = "1.8.0"
 description = "Optional static typing for Python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
@@ -983,7 +983,7 @@ reports = ["lxml"]
 name = "mypy-extensions"
 version = "1.0.0"
 description = "Type system extensions for programs checked with the mypy type checker."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.5"
 files = [
@@ -1990,6 +1990,8 @@ files = [
 
 [package.dependencies]
 greenlet = {version = "!=0.4.17", markers = "python_version >= \"3\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")"}
+mypy = {version = ">=0.910", optional = true, markers = "python_version >= \"3\" and extra == \"mypy\""}
+sqlalchemy2-stubs = {version = "*", optional = true, markers = "extra == \"mypy\""}
 
 [package.extras]
 aiomysql = ["aiomysql (>=0.2.0)", "greenlet (!=0.4.17)"]
@@ -2013,19 +2015,18 @@ pymysql = ["pymysql", "pymysql (<1)"]
 sqlcipher = ["sqlcipher3_binary"]
 
 [[package]]
-name = "sqlalchemy-stubs"
-version = "0.4"
-description = "SQLAlchemy stubs and mypy plugin"
-category = "dev"
+name = "sqlalchemy2-stubs"
+version = "0.0.2a38"
+description = "Typing Stubs for SQLAlchemy 1.4"
+category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 files = [
-    {file = "sqlalchemy-stubs-0.4.tar.gz", hash = "sha256:c665d6dd4482ef642f01027fa06c3d5e91befabb219dc71fc2a09e7d7695f7ae"},
-    {file = "sqlalchemy_stubs-0.4-py3-none-any.whl", hash = "sha256:5eec7aa110adf9b957b631799a72fef396b23ff99fe296df726645d01e312aa5"},
+    {file = "sqlalchemy2-stubs-0.0.2a38.tar.gz", hash = "sha256:861d722abeb12f13eacd775a9f09379b11a5a9076f469ccd4099961b95800f9e"},
+    {file = "sqlalchemy2_stubs-0.0.2a38-py3-none-any.whl", hash = "sha256:b62aa46943807287550e2033dafe07564b33b6a815fbaa3c144e396f9cc53bcb"},
 ]
 
 [package.dependencies]
-mypy = ">=0.790"
 typing-extensions = ">=3.7.4"
 
 [[package]]
@@ -2066,7 +2067,7 @@ pbr = ">=2.0.0,<2.1.0 || >2.1.0"
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -2374,4 +2375,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9" 
-content-hash = "70f03c84d5f4b0bb65f81635b95e40298e4c625db50a5c91eb1934dadb12dd8b"
+content-hash = "e49adedb85d8b3c65943715d79822fe4ad8455b904a409fdd9c24deecbd98719"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = [
 version = "5.2.3"
 
 [tool.poetry.dependencies]
-SQLAlchemy = "^1.4.42" 
+SQLAlchemy = {version = "<2.0", extras = ["mypy"]} 
 fastapi = "^0.109.0" 
 fastapi-pagination = {extras = ["sqlalchemy"], version = "^0.12.1"} 
 httpx = "^0.23.0" 
@@ -40,7 +40,7 @@ pytest-httpx = "^0.21"
 pytest-mock = "^3.11.1"
 pytest-postgresql = "^3.1.1"
 ruff = "^0.1.3"
-sqlalchemy-stubs = "*"
+sqlalchemy2-stubs = "*"
 tox = "^4.12.1"
 types-python-dateutil = "^2.8.19.13"
 
@@ -57,7 +57,7 @@ exclude = ["tests/"]
 
 [tool.mypy]
 plugins = [
-  "sqlmypy",
+  "sqlalchemy.ext.mypy.plugin",
   "pydantic.mypy",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ build-backend = "poetry.core.masonry.api"
 requires = ["poetry-core>=1.0.0"]
 
 [tool.ruff]
-exclude = ["tests/"]
 
 [tool.ruff.format]
 
@@ -60,6 +59,7 @@ plugins = [
   "sqlalchemy.ext.mypy.plugin",
   "pydantic.mypy",
 ]
+exclude = ["tests/", "scripts/"]
 
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
@@ -68,6 +68,7 @@ module = [
   "okta_jwt_verifier.*",
   "uvicorn.*",
   "redis.*",
+  "matplotlib.*",
   "ukrdc_xsdata.*",
 ]
 

--- a/scripts/analytics/query_memberships.py
+++ b/scripts/analytics/query_memberships.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 
-from sqlalchemy import and_
+from sqlalchemy import and_, select
 from sqlalchemy.orm import Session
 from ukrdc_fastapi.dependencies.audit import AuditOperation, Resource
 from ukrdc_fastapi.dependencies.database import AuditSession
@@ -20,17 +20,15 @@ def json_serial(obj):
 
 session: Session = AuditSession()
 
-membership_creations = (
-    session.query(AuditEvent)
-    .filter(
-        and_(
-            AuditEvent.resource == Resource.MEMBERSHIP.value,
-            AuditEvent.operation == AuditOperation.CREATE.value,
-            AuditEvent.resource_id == "PKB",
-        )
+stmt = select(AuditEvent).where(
+    and_(
+        AuditEvent.resource == Resource.MEMBERSHIP.value,
+        AuditEvent.operation == AuditOperation.CREATE.value,
+        AuditEvent.resource_id == "PKB",
     )
-    .all()
 )
+
+membership_creations = session.scalars(stmt).all()
 
 print(len(membership_creations))
 

--- a/scripts/type_9_resolver/process.py
+++ b/scripts/type_9_resolver/process.py
@@ -1,7 +1,7 @@
 import asyncio
 from ukrdc_fastapi.dependencies.mirth import mirth_session
 from ukrdc_fastapi.query.workitems import extend_workitem
-from ukrdc_fastapi.query.messages import get_messages
+from ukrdc_fastapi.query.messages import select_messages
 from ukrdc_fastapi.dependencies.database import jtrace_session, errors_session
 from ukrdc_fastapi.schemas.message import MessageSchema
 from ukrdc_sqla.empi import WorkItem
@@ -32,7 +32,7 @@ async def process_workitem(workitem_id: int):
 
         messages = [
             MessageSchema.from_orm(msg)
-            for msg in get_messages(
+            for msg in select_messages(
                 errorsdb,
                 statuses=["ERROR"],
                 nis=workitem_nis,

--- a/scripts/type_9_resolver/process.py
+++ b/scripts/type_9_resolver/process.py
@@ -16,7 +16,7 @@ CHANNEL_IDS = [RDA_INBOUND_FILE, PV_INBOUND]
 async def process_workitem(workitem_id: int):
     # Find workitem and related messages
     with jtrace_session() as jtrace, errors_session() as errorsdb:
-        workitem_obj = extend_workitem(jtrace.query(WorkItem).get(workitem_id), jtrace)
+        workitem_obj = extend_workitem(jtrace.get(WorkItem, workitem_id), jtrace)
 
         assert workitem_obj.type == 9
 

--- a/scripts/ukrdc_dupes/find.py
+++ b/scripts/ukrdc_dupes/find.py
@@ -6,7 +6,9 @@ from ukrdc_sqla.empi import MasterRecord
 
 from ukrdc_fastapi.dependencies.auth import Permissions, UKRDCUser
 from ukrdc_fastapi.dependencies.database import JtraceSession
-from ukrdc_fastapi.query.masterrecords import get_masterrecords_related_to_masterrecord
+from ukrdc_fastapi.query.masterrecords import (
+    select_masterrecords_related_to_masterrecord,
+)
 
 USER = UKRDCUser(id="", email="", scopes=[], permissions=Permissions.all())
 
@@ -29,7 +31,7 @@ def find_ukrdc_dupes(jtrace: Session):
 
     for record in records:
         print(f"Processing record {record.id}")
-        related_ukrdc_records = get_masterrecords_related_to_masterrecord(
+        related_ukrdc_records = select_masterrecords_related_to_masterrecord(
             jtrace,
             record.id,
         ).filter(MasterRecord.nationalid_type == "UKRDC")

--- a/scripts/ukrdc_dupes/find.py
+++ b/scripts/ukrdc_dupes/find.py
@@ -1,5 +1,6 @@
 import json
 import os
+from sqlalchemy import select
 
 from sqlalchemy.orm import Session
 from ukrdc_sqla.empi import MasterRecord
@@ -25,9 +26,9 @@ def find_ukrdc_dupes(jtrace: Session):
         results = {"cleared": [], "failed": {}}
 
     print("Fetching records")
-    records: MasterRecord = jtrace.query(MasterRecord).filter(
-        MasterRecord.id.notin_(results["cleared"])
-    )
+
+    stmt = select(MasterRecord).where(MasterRecord.id.not_in_(results["cleared"]))
+    records = jtrace.scalars(stmt).all()
 
     for record in records:
         print(f"Processing record {record.id}")

--- a/tests/test_audit/test_audit.py
+++ b/tests/test_audit/test_audit.py
@@ -15,7 +15,7 @@ async def test_access_event(client_superuser, audit_session):
     assert event.resource == "PATIENT_RECORD"
     assert event.operation == "READ"
     assert event.resource_id == "PYTEST01:PV:00000000A"
-    assert event.parent_id == None
+    assert event.parent_id is None
     assert event.children == []
 
     access_event = events[0].access_event

--- a/tests/test_audit/test_audit.py
+++ b/tests/test_audit/test_audit.py
@@ -1,3 +1,4 @@
+from sqlalchemy import select
 from ukrdc_fastapi.config import configuration
 from ukrdc_fastapi.models.audit import AuditEvent
 
@@ -7,7 +8,7 @@ async def test_access_event(client_superuser, audit_session):
     response = await client_superuser.get(path)
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 1
 
     event = events[0]

--- a/tests/test_audit/test_audit_facilities.py
+++ b/tests/test_audit/test_audit_facilities.py
@@ -1,3 +1,4 @@
+from sqlalchemy import select
 from ukrdc_fastapi.config import configuration
 from ukrdc_fastapi.models.audit import AuditEvent
 
@@ -8,7 +9,7 @@ async def test_facility_messages(client_superuser, audit_session):
     )
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 2
 
     event = events[0]

--- a/tests/test_audit/test_audit_facilities.py
+++ b/tests/test_audit/test_audit_facilities.py
@@ -18,7 +18,7 @@ async def test_facility_messages(client_superuser, audit_session):
     assert event.resource == "FACILITY"
     assert event.operation == "READ"
     assert event.resource_id == "TSF01"
-    assert event.parent_id == None
+    assert event.parent_id is None
 
     child_event = event.children[0]
     assert child_event.resource == "MESSAGES"

--- a/tests/test_audit/test_audit_masterrecords.py
+++ b/tests/test_audit/test_audit_masterrecords.py
@@ -18,7 +18,7 @@ async def test_masterrecord_detail(client, audit_session):
     assert event.resource == "MASTER_RECORD"
     assert event.operation == "READ"
     assert event.resource_id == "1"
-    assert event.parent_id == None
+    assert event.parent_id is None
 
 
 async def test_masterrecord_related(client_superuser, audit_session):
@@ -41,7 +41,7 @@ async def test_masterrecord_related(client_superuser, audit_session):
     assert primary_event.resource == "MASTER_RECORD"
     assert primary_event.operation == "READ"
     assert primary_event.resource_id == "1"
-    assert primary_event.parent_id == None
+    assert primary_event.parent_id is None
 
     for child_event in primary_event.children:
         assert child_event.resource == "MASTER_RECORD"
@@ -65,12 +65,12 @@ async def test_masterrecord_statistics(client_superuser, audit_session):
     assert event.resource == "MASTER_RECORD"
     assert event.operation == "READ"
     assert event.resource_id == "1"
-    assert event.parent_id == None
+    assert event.parent_id is None
 
     child_event = event.children[0]
     assert child_event.resource == "STATISTICS"
     assert child_event.operation == "READ"
-    assert child_event.resource_id == None
+    assert child_event.resource_id is None
     assert child_event.parent_id == event.id
 
 
@@ -89,7 +89,7 @@ async def test_masterrecord_linkrecords(client_superuser, audit_session):
     assert event.resource == "MASTER_RECORD"
     assert event.operation == "READ"
     assert event.resource_id == "1"
-    assert event.parent_id == None
+    assert event.parent_id is None
 
     for child_event in event.children:
         assert child_event.operation == "READ"
@@ -130,7 +130,7 @@ async def test_masterrecord_messages(client_superuser, audit_session):
     assert event.resource == "MASTER_RECORD"
     assert event.operation == "READ"
     assert event.resource_id == "1"
-    assert event.parent_id == None
+    assert event.parent_id is None
 
     child_event = event.children[0]
     assert child_event.resource == "MESSAGES"
@@ -154,7 +154,7 @@ async def test_masterrecord_workitems(client_superuser, audit_session):
     assert event.resource == "MASTER_RECORD"
     assert event.operation == "READ"
     assert event.resource_id == "1"
-    assert event.parent_id == None
+    assert event.parent_id is None
 
     for i, workitem_event in enumerate(event.children):
         assert workitem_event.resource == "WORKITEM"
@@ -195,7 +195,7 @@ async def test_masterrecord_persons(client_superuser, audit_session):
     assert primary_event.resource == "MASTER_RECORD"
     assert primary_event.operation == "READ"
     assert primary_event.resource_id == "1"
-    assert primary_event.parent_id == None
+    assert primary_event.parent_id is None
 
     for child_event in primary_event.children:
         assert child_event.resource == "PERSON"
@@ -222,7 +222,7 @@ async def test_masterrecord_patientrecords(client_superuser, audit_session):
     assert primary_event.resource == "MASTER_RECORD"
     assert primary_event.operation == "READ"
     assert primary_event.resource_id == "1"
-    assert primary_event.parent_id == None
+    assert primary_event.parent_id is None
 
     for child_event in primary_event.children:
         assert child_event.resource == "PATIENT_RECORD"

--- a/tests/test_audit/test_audit_masterrecords.py
+++ b/tests/test_audit/test_audit_masterrecords.py
@@ -1,3 +1,4 @@
+from sqlalchemy import select
 from ukrdc_fastapi.config import configuration
 from ukrdc_fastapi.models.audit import AuditEvent
 from ukrdc_fastapi.schemas.empi import MasterRecordSchema, PersonSchema, WorkItemSchema
@@ -8,7 +9,7 @@ async def test_masterrecord_detail(client, audit_session):
     response = await client.get(f"{configuration.base_url}/masterrecords/1")
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 1
 
     event = events[0]
@@ -31,7 +32,7 @@ async def test_masterrecord_related(client_superuser, audit_session):
     returned_ids = {item.id for item in mrecs}
     assert returned_ids == {4, 101, 104}
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 4
 
     primary_event = events[0]
@@ -55,7 +56,7 @@ async def test_masterrecord_statistics(client_superuser, audit_session):
     )
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 2
 
     event = events[0]
@@ -79,7 +80,7 @@ async def test_masterrecord_linkrecords(client_superuser, audit_session):
     )
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 7
 
     event = events[0]
@@ -120,7 +121,7 @@ async def test_masterrecord_messages(client_superuser, audit_session):
     )
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 2
 
     event = events[0]
@@ -144,7 +145,7 @@ async def test_masterrecord_workitems(client_superuser, audit_session):
     assert response.status_code == 200
     workitems = [WorkItemSchema(**item) for item in response.json()]
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 7
 
     event = events[0]
@@ -185,7 +186,7 @@ async def test_masterrecord_persons(client_superuser, audit_session):
     returned_ids = {item.id for item in persons}
     assert returned_ids == {1, 4}
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 3
 
     primary_event = events[0]
@@ -212,7 +213,7 @@ async def test_masterrecord_patientrecords(client_superuser, audit_session):
     returned_pids = {item.pid for item in records}
     assert returned_pids == {"PYTEST01:PV:00000000A", "PYTEST04:PV:00000000A"}
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 3
 
     primary_event = events[0]

--- a/tests/test_audit/test_audit_messages.py
+++ b/tests/test_audit/test_audit_messages.py
@@ -17,8 +17,8 @@ async def test_messages_list(client_superuser, audit_session):
 
     assert event.resource == "MESSAGES"
     assert event.operation == "READ"
-    assert event.resource_id == None
-    assert event.parent_id == None
+    assert event.resource_id is None
+    assert event.parent_id is None
 
 
 async def test_message_detail(client_superuser, audit_session):
@@ -34,7 +34,7 @@ async def test_message_detail(client_superuser, audit_session):
     assert event.resource == "MESSAGE"
     assert event.operation == "READ"
     assert event.resource_id == "1"
-    assert event.parent_id == None
+    assert event.parent_id is None
 
 
 async def test_message_workitems(client_superuser, audit_session):
@@ -52,7 +52,7 @@ async def test_message_workitems(client_superuser, audit_session):
     assert event.resource == "MESSAGE"
     assert event.operation == "READ"
     assert event.resource_id == "3"
-    assert event.parent_id == None
+    assert event.parent_id is None
 
     for i, workitem_event in enumerate(event.children):
         assert workitem_event.resource == "WORKITEM"
@@ -92,7 +92,7 @@ async def test_message_patientrecords(client_superuser, audit_session):
     assert primary_event.resource == "MESSAGE"
     assert primary_event.operation == "READ"
     assert primary_event.resource_id == "1"
-    assert primary_event.parent_id == None
+    assert primary_event.parent_id is None
 
     for child_event in primary_event.children:
         assert child_event.resource == "PATIENT_RECORD"

--- a/tests/test_audit/test_audit_messages.py
+++ b/tests/test_audit/test_audit_messages.py
@@ -1,3 +1,4 @@
+from sqlalchemy import select
 from tests.conftest import PID_1
 from ukrdc_fastapi.config import configuration
 from ukrdc_fastapi.models.audit import AuditEvent
@@ -8,7 +9,7 @@ async def test_messages_list(client_superuser, audit_session):
     response = await client_superuser.get(f"{configuration.base_url}/messages")
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 1
 
     event = events[0]
@@ -24,7 +25,7 @@ async def test_message_detail(client_superuser, audit_session):
     response = await client_superuser.get(f"{configuration.base_url}/messages/1")
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 1
 
     event = events[0]
@@ -42,7 +43,7 @@ async def test_message_workitems(client_superuser, audit_session):
     )
     workitems = [WorkItemSchema(**item) for item in response.json()]
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 4
 
     event = events[0]
@@ -82,7 +83,7 @@ async def test_message_patientrecords(client_superuser, audit_session):
     returned_pids = {item.get("pid") for item in response.json()}
     assert returned_pids == {PID_1}
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 2
 
     primary_event = events[0]

--- a/tests/test_audit/test_audit_patientrecords.py
+++ b/tests/test_audit/test_audit_patientrecords.py
@@ -22,7 +22,7 @@ async def test_record_read_audit(client_superuser, audit_session):
     assert event.resource == "PATIENT_RECORD"
     assert event.operation == "READ"
     assert event.resource_id == "PYTEST01:PV:00000000A"
-    assert event.parent_id == None
+    assert event.parent_id is None
 
 
 async def test_record_delete_summary_audit(client_superuser, audit_session):
@@ -101,12 +101,12 @@ async def test_record_read_medications(client_superuser, audit_session):
     assert event.resource == "PATIENT_RECORD"
     assert event.operation == "READ"
     assert event.resource_id == "PYTEST01:PV:00000000A"
-    assert event.parent_id == None
+    assert event.parent_id is None
 
     child_event = event.children[0]
     assert child_event.resource == "MEDICATIONS"
     assert child_event.operation == "READ"
-    assert child_event.resource_id == None
+    assert child_event.resource_id is None
     assert child_event.parent_id == event.id
 
 
@@ -125,12 +125,12 @@ async def test_record_read_treatments(client_superuser, audit_session):
     assert event.resource == "PATIENT_RECORD"
     assert event.operation == "READ"
     assert event.resource_id == "PYTEST01:PV:00000000A"
-    assert event.parent_id == None
+    assert event.parent_id is None
 
     child_event = event.children[0]
     assert child_event.resource == "TREATMENTS"
     assert child_event.operation == "READ"
-    assert child_event.resource_id == None
+    assert child_event.resource_id is None
     assert child_event.parent_id == event.id
 
 
@@ -149,12 +149,12 @@ async def test_record_read_surveys(client_superuser, audit_session):
     assert event.resource == "PATIENT_RECORD"
     assert event.operation == "READ"
     assert event.resource_id == "PYTEST01:PV:00000000A"
-    assert event.parent_id == None
+    assert event.parent_id is None
 
     child_event = event.children[0]
     assert child_event.resource == "SURVEYS"
     assert child_event.operation == "READ"
-    assert child_event.resource_id == None
+    assert child_event.resource_id is None
     assert child_event.parent_id == event.id
 
 
@@ -173,12 +173,12 @@ async def test_record_read_observations(client_superuser, audit_session):
     assert event.resource == "PATIENT_RECORD"
     assert event.operation == "READ"
     assert event.resource_id == "PYTEST01:PV:00000000A"
-    assert event.parent_id == None
+    assert event.parent_id is None
 
     child_event = event.children[0]
     assert child_event.resource == "OBSERVATIONS"
     assert child_event.operation == "READ"
-    assert child_event.resource_id == None
+    assert child_event.resource_id is None
     assert child_event.parent_id == event.id
 
 
@@ -197,12 +197,12 @@ async def test_record_read_laborders(client_superuser, audit_session):
     assert event.resource == "PATIENT_RECORD"
     assert event.operation == "READ"
     assert event.resource_id == "PYTEST01:PV:00000000A"
-    assert event.parent_id == None
+    assert event.parent_id is None
 
     child_event = event.children[0]
     assert child_event.resource == "LABORDERS"
     assert child_event.operation == "READ"
-    assert child_event.resource_id == None
+    assert child_event.resource_id is None
     assert child_event.parent_id == event.id
 
 
@@ -221,7 +221,7 @@ async def test_record_read_laborder(client_superuser, audit_session):
     assert event.resource == "PATIENT_RECORD"
     assert event.operation == "READ"
     assert event.resource_id == "PYTEST01:PV:00000000A"
-    assert event.parent_id == None
+    assert event.parent_id is None
 
     child_event = event.children[0]
     assert child_event.resource == "LABORDER"
@@ -270,7 +270,7 @@ async def test_record_delete_laborder(client_superuser, ukrdc3_session, audit_se
     assert record_event.resource == "PATIENT_RECORD"
     assert record_event.operation == "UPDATE"
     assert record_event.resource_id == "PYTEST01:PV:00000000A"
-    assert record_event.parent_id == None
+    assert record_event.parent_id is None
 
     order_event = record_event.children[0]
     assert len(order_event.children) == 1
@@ -304,12 +304,12 @@ async def test_record_read_resultitems(client_superuser, audit_session):
     assert event.resource == "PATIENT_RECORD"
     assert event.operation == "READ"
     assert event.resource_id == "PYTEST01:PV:00000000A"
-    assert event.parent_id == None
+    assert event.parent_id is None
 
     child_event = event.children[0]
     assert child_event.resource == "RESULTITEMS"
     assert child_event.operation == "READ"
-    assert child_event.resource_id == None
+    assert child_event.resource_id is None
     assert child_event.parent_id == event.id
 
 
@@ -328,7 +328,7 @@ async def test_record_read_resultitem(client_superuser, audit_session):
     assert event.resource == "PATIENT_RECORD"
     assert event.operation == "READ"
     assert event.resource_id == "PYTEST01:PV:00000000A"
-    assert event.parent_id == None
+    assert event.parent_id is None
 
     child_event = event.children[0]
     assert child_event.resource == "RESULTITEM"
@@ -352,7 +352,7 @@ async def test_record_delete_resultitem(client_superuser, audit_session):
     assert event.resource == "PATIENT_RECORD"
     assert event.operation == "UPDATE"
     assert event.resource_id == "PYTEST01:PV:00000000A"
-    assert event.parent_id == None
+    assert event.parent_id is None
 
     child_event = event.children[0]
     assert child_event.resource == "RESULTITEM"
@@ -376,12 +376,12 @@ async def test_record_read_documents(client_superuser, audit_session):
     assert event.resource == "PATIENT_RECORD"
     assert event.operation == "READ"
     assert event.resource_id == "PYTEST01:PV:00000000A"
-    assert event.parent_id == None
+    assert event.parent_id is None
 
     child_event = event.children[0]
     assert child_event.resource == "DOCUMENTS"
     assert child_event.operation == "READ"
-    assert child_event.resource_id == None
+    assert child_event.resource_id is None
     assert child_event.parent_id == event.id
 
 
@@ -400,7 +400,7 @@ async def test_record_read_document(client_superuser, audit_session):
     assert event.resource == "PATIENT_RECORD"
     assert event.operation == "READ"
     assert event.resource_id == "PYTEST01:PV:00000000A"
-    assert event.parent_id == None
+    assert event.parent_id is None
 
     child_event = event.children[0]
     assert child_event.resource == "DOCUMENT"
@@ -424,7 +424,7 @@ async def test_record_download_document(client_superuser, audit_session):
     assert event.resource == "PATIENT_RECORD"
     assert event.operation == "READ"
     assert event.resource_id == "PYTEST01:PV:00000000A"
-    assert event.parent_id == None
+    assert event.parent_id is None
 
     child_event = event.children[0]
     assert child_event.resource == "DOCUMENT"
@@ -449,7 +449,7 @@ async def test_record_export_data(client_superuser, audit_session):
     assert event.resource == "PATIENT_RECORD"
     assert event.operation == "EXPORT_PV"
     assert event.resource_id == "PYTEST01:PV:00000000A"
-    assert event.parent_id == None
+    assert event.parent_id is None
 
 
 async def test_record_export_tests(client_superuser, audit_session):
@@ -468,7 +468,7 @@ async def test_record_export_tests(client_superuser, audit_session):
     assert event.resource == "PATIENT_RECORD"
     assert event.operation == "EXPORT_PV_TESTS"
     assert event.resource_id == "PYTEST01:PV:00000000A"
-    assert event.parent_id == None
+    assert event.parent_id is None
 
 
 async def test_record_export_docs(client_superuser, audit_session):
@@ -487,7 +487,7 @@ async def test_record_export_docs(client_superuser, audit_session):
     assert event.resource == "PATIENT_RECORD"
     assert event.operation == "EXPORT_PV_DOCS"
     assert event.resource_id == "PYTEST01:PV:00000000A"
-    assert event.parent_id == None
+    assert event.parent_id is None
 
 
 async def test_record_export_radar(client_superuser, audit_session):
@@ -506,4 +506,4 @@ async def test_record_export_radar(client_superuser, audit_session):
     assert event.resource == "PATIENT_RECORD"
     assert event.operation == "EXPORT_RADAR"
     assert event.resource_id == "PYTEST01:PV:00000000A"
-    assert event.parent_id == None
+    assert event.parent_id is None

--- a/tests/test_audit/test_audit_patientrecords.py
+++ b/tests/test_audit/test_audit_patientrecords.py
@@ -1,3 +1,4 @@
+from sqlalchemy import select
 from ukrdc_sqla.ukrdc import LabOrder, ResultItem
 
 from ukrdc_fastapi.config import configuration
@@ -12,7 +13,7 @@ async def test_record_read_audit(client_superuser, audit_session):
     )
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 1
 
     event = events[0]
@@ -30,7 +31,7 @@ async def test_record_delete_summary_audit(client_superuser, audit_session):
     )
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 4
 
     # All events should be related to the primary event
@@ -63,7 +64,7 @@ async def test_record_delete_audit(client_superuser, audit_session):
 
     assert deleted_response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 8
 
     # We get 4 events for the delete summary and 4 for the actual delete
@@ -91,7 +92,7 @@ async def test_record_read_medications(client_superuser, audit_session):
     )
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 2
 
     event = events[0]
@@ -115,7 +116,7 @@ async def test_record_read_treatments(client_superuser, audit_session):
     )
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 2
 
     event = events[0]
@@ -139,7 +140,7 @@ async def test_record_read_surveys(client_superuser, audit_session):
     )
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 2
 
     event = events[0]
@@ -163,7 +164,7 @@ async def test_record_read_observations(client_superuser, audit_session):
     )
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 2
 
     event = events[0]
@@ -187,7 +188,7 @@ async def test_record_read_laborders(client_superuser, audit_session):
     )
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 2
 
     event = events[0]
@@ -211,7 +212,7 @@ async def test_record_read_laborder(client_superuser, audit_session):
     )
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 2
 
     event = events[0]
@@ -252,15 +253,15 @@ async def test_record_delete_laborder(client_superuser, ukrdc3_session, audit_se
     ukrdc3_session.commit()
 
     # Make sure the laborder was created
-    assert ukrdc3_session.query(LabOrder).get("LABORDER_TEMP")
-    assert ukrdc3_session.query(ResultItem).get("RESULTITEM_TEMP")
+    assert ukrdc3_session.get(LabOrder, "LABORDER_TEMP")
+    assert ukrdc3_session.get(ResultItem, "RESULTITEM_TEMP")
 
     response = await client_superuser.delete(
         f"{configuration.base_url}/patientrecords/PYTEST01:PV:00000000A/laborders/LABORDER_TEMP"
     )
     assert response.status_code == 204
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 3
 
     record_event = events[0]
@@ -294,7 +295,7 @@ async def test_record_read_resultitems(client_superuser, audit_session):
     )
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 2
 
     event = events[0]
@@ -318,7 +319,7 @@ async def test_record_read_resultitem(client_superuser, audit_session):
     )
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 2
 
     event = events[0]
@@ -342,7 +343,7 @@ async def test_record_delete_resultitem(client_superuser, audit_session):
     )
     assert response.status_code == 204
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 2
 
     event = events[0]
@@ -366,7 +367,7 @@ async def test_record_read_documents(client_superuser, audit_session):
     )
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 2
 
     event = events[0]
@@ -390,7 +391,7 @@ async def test_record_read_document(client_superuser, audit_session):
     )
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 2
 
     event = events[0]
@@ -414,7 +415,7 @@ async def test_record_download_document(client_superuser, audit_session):
     )
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 2
 
     event = events[0]
@@ -439,7 +440,7 @@ async def test_record_export_data(client_superuser, audit_session):
     )
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 1
 
     event = events[0]
@@ -458,7 +459,7 @@ async def test_record_export_tests(client_superuser, audit_session):
     )
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 1
 
     event = events[0]
@@ -477,7 +478,7 @@ async def test_record_export_docs(client_superuser, audit_session):
     )
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 1
 
     event = events[0]
@@ -496,7 +497,7 @@ async def test_record_export_radar(client_superuser, audit_session):
     )
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 1
 
     event = events[0]

--- a/tests/test_audit/test_audit_search.py
+++ b/tests/test_audit/test_audit_search.py
@@ -19,4 +19,4 @@ async def test_search_pid(client_superuser, audit_session):
         assert event.resource == "MASTER_RECORD"
         assert event.operation == "READ"
         assert int(event.resource_id) in returned_ids
-        assert event.parent_id == None
+        assert event.parent_id is None

--- a/tests/test_audit/test_audit_search.py
+++ b/tests/test_audit/test_audit_search.py
@@ -1,3 +1,4 @@
+from sqlalchemy import select
 from ukrdc_fastapi.config import configuration
 from ukrdc_fastapi.models.audit import AuditEvent
 
@@ -11,7 +12,7 @@ async def test_search_pid(client_superuser, audit_session):
     returned_ids = {item["id"] for item in response.json()["items"]}
     assert returned_ids == {104, 1, 4, 101}
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 4
 
     for event in events:

--- a/tests/test_audit/test_audit_workitems.py
+++ b/tests/test_audit/test_audit_workitems.py
@@ -18,6 +18,8 @@ def _verify_workitem_audit(workitem: WorkItemSchema, workitem_event: AuditEvent)
         child for child in workitem_event.children if child.resource == "PERSON"
     ][0]
 
+    assert workitem.master_record
+    assert workitem.person
     assert master_record_event.resource_id == str(workitem.master_record.id)
     assert person_event.resource_id == str(workitem.person.id)
 
@@ -38,6 +40,9 @@ def _verify_extended_workitem_audit(
 
     expected_master_ids = set()
     expected_person_ids = set()
+
+    assert workitem.destination.master_record
+    assert workitem.incoming.person
 
     for master_record in workitem.incoming.master_records:
         expected_master_ids.add(str(master_record.id))
@@ -150,7 +155,7 @@ async def test_workitem_messages(client_superuser, audit_session):
     assert event.resource == "WORKITEM"
     assert event.operation == "READ"
     assert event.resource_id == "1"
-    assert event.parent_id == None
+    assert event.parent_id is None
 
     child_event = event.children[0]
     assert child_event.resource == "MESSAGES"

--- a/tests/test_audit/test_audit_workitems.py
+++ b/tests/test_audit/test_audit_workitems.py
@@ -1,3 +1,4 @@
+from sqlalchemy import select
 from ukrdc_fastapi.config import configuration
 from ukrdc_fastapi.models.audit import AuditEvent
 from ukrdc_fastapi.schemas.empi import WorkItemExtendedSchema, WorkItemSchema
@@ -59,7 +60,7 @@ async def test_workitems_list(client_superuser, audit_session):
     assert response.status_code == 200
     workitems = [WorkItemSchema(**wi) for wi in response.json().get("items")]
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
 
     workitem_events = [event for event in events if event.resource == "WORKITEM"]
     assert len(workitem_events) == len(workitems)
@@ -73,7 +74,7 @@ async def test_workitem_detail(client_superuser, audit_session):
     assert response.status_code == 200
     wi = WorkItemExtendedSchema(**response.json())
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 6
 
     primary_event = events[0]
@@ -90,7 +91,7 @@ async def test_workitem_update(client_superuser, audit_session):
     assert response.status_code == 200
     assert response.json().get("status") == "success"
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 1
 
     event = events[0]
@@ -106,7 +107,7 @@ async def test_workitem_close(client_superuser, audit_session):
     )
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 1
 
     event = events[0]
@@ -125,7 +126,7 @@ async def test_workitems_related(client_superuser, audit_session):
     returned_ids = {item.id for item in workitems}
     assert returned_ids == {2, 3, 4}
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
 
     workitem_events = [event for event in events if event.resource == "WORKITEM"]
     assert len(workitem_events) == len(workitems)
@@ -140,7 +141,7 @@ async def test_workitem_messages(client_superuser, audit_session):
     )
     assert response.status_code == 200
 
-    events = audit_session.query(AuditEvent).all()
+    events = audit_session.scalars(select(AuditEvent)).all()
     assert len(events) == 2
 
     event = events[0]

--- a/tests/test_query/test_audit.py
+++ b/tests/test_query/test_audit.py
@@ -24,9 +24,9 @@ async def test_record_read_audit(
     # Test audit patient filtering
     record = ukrdc3_session.get(PatientRecord, PID_1)
 
-    events = audit_session.scalars(select_auditevents_related_to_patientrecord(
-        record
-    )).all()
+    events = audit_session.scalars(
+        select_auditevents_related_to_patientrecord(record)
+    ).all()
 
     assert len(events) == 1
 
@@ -57,10 +57,12 @@ async def test_record_results_read_audit(
 
     # Test audit patient filtering
     record = ukrdc3_session.get(PatientRecord, PID_1)
-    events = audit_session.scalars(select_auditevents_related_to_patientrecord(
-        record,
-        resource=Resource.RESULTITEMS,
-    )).all()
+    events = audit_session.scalars(
+        select_auditevents_related_to_patientrecord(
+            record,
+            resource=Resource.RESULTITEMS,
+        )
+    ).all()
 
     assert len(events) == 1
 
@@ -89,10 +91,12 @@ async def test_record_pkb_membership_resource_audit(
 
     # Test audit patient and resource filtering
     record = ukrdc3_session.get(PatientRecord, PID_1)
-    events = audit_session.scalars(select_auditevents_related_to_patientrecord(
-        record,
-        resource=Resource.MEMBERSHIP,
-    )).all()
+    events = audit_session.scalars(
+        select_auditevents_related_to_patientrecord(
+            record,
+            resource=Resource.MEMBERSHIP,
+        )
+    ).all()
 
     assert len(events) == 1
 
@@ -122,10 +126,12 @@ async def test_record_create_operation_audit(
 
     # Test audit patient and resource filtering
     record = ukrdc3_session.get(PatientRecord, PID_1)
-    events = audit_session.scalars(select_auditevents_related_to_patientrecord(
-        record,
-        operation=AuditOperation.CREATE,
-    )).all()
+    events = audit_session.scalars(
+        select_auditevents_related_to_patientrecord(
+            record,
+            operation=AuditOperation.CREATE,
+        )
+    ).all()
 
     assert len(events) == 1
 

--- a/tests/test_query/test_audit.py
+++ b/tests/test_query/test_audit.py
@@ -2,7 +2,7 @@ from tests.conftest import PID_1, PID_2, UKRDCID_1, UKRDCID_2
 from ukrdc_fastapi.config import configuration
 from ukrdc_fastapi.dependencies.audit import AuditOperation, Resource
 from ukrdc_sqla.ukrdc import PatientRecord
-from ukrdc_fastapi.query.audit import get_auditevents_related_to_patientrecord
+from ukrdc_fastapi.query.audit import select_auditevents_related_to_patientrecord
 
 
 async def test_record_read_audit(
@@ -22,10 +22,11 @@ async def test_record_read_audit(
     assert response.status_code == 200
 
     # Test audit patient filtering
+    record = ukrdc3_session.get(PatientRecord, PID_1)
 
-    events = get_auditevents_related_to_patientrecord(
-        ukrdc3_session.query(PatientRecord).get(PID_1), audit_session
-    ).all()
+    events = audit_session.scalars(select_auditevents_related_to_patientrecord(
+        record
+    )).all()
 
     assert len(events) == 1
 
@@ -55,12 +56,11 @@ async def test_record_results_read_audit(
     assert response.status_code == 200
 
     # Test audit patient filtering
-
-    events = get_auditevents_related_to_patientrecord(
-        ukrdc3_session.query(PatientRecord).get(PID_1),
-        audit_session,
+    record = ukrdc3_session.get(PatientRecord, PID_1)
+    events = audit_session.scalars(select_auditevents_related_to_patientrecord(
+        record,
         resource=Resource.RESULTITEMS,
-    ).all()
+    )).all()
 
     assert len(events) == 1
 
@@ -88,12 +88,11 @@ async def test_record_pkb_membership_resource_audit(
     assert response.status_code == 200
 
     # Test audit patient and resource filtering
-
-    events = get_auditevents_related_to_patientrecord(
-        ukrdc3_session.query(PatientRecord).get(PID_1),
-        audit_session,
+    record = ukrdc3_session.get(PatientRecord, PID_1)
+    events = audit_session.scalars(select_auditevents_related_to_patientrecord(
+        record,
         resource=Resource.MEMBERSHIP,
-    ).all()
+    )).all()
 
     assert len(events) == 1
 
@@ -122,12 +121,11 @@ async def test_record_create_operation_audit(
     assert response.status_code == 200
 
     # Test audit patient and resource filtering
-
-    events = get_auditevents_related_to_patientrecord(
-        ukrdc3_session.query(PatientRecord).get(PID_1),
-        audit_session,
+    record = ukrdc3_session.get(PatientRecord, PID_1)
+    events = audit_session.scalars(select_auditevents_related_to_patientrecord(
+        record,
         operation=AuditOperation.CREATE,
-    ).all()
+    )).all()
 
     assert len(events) == 1
 

--- a/tests/test_query/test_codes.py
+++ b/tests/test_query/test_codes.py
@@ -5,7 +5,7 @@ from ..utils import days_ago
 
 
 def test_get_codes(ukrdc3_session):
-    code_list = codes.get_codes(ukrdc3_session).all()
+    code_list = ukrdc3_session.scalars(codes.select_codes()).all()
     assert {code.code for code in code_list} == {
         "TSF01",
         "TSF02",
@@ -17,15 +17,15 @@ def test_get_codes(ukrdc3_session):
 
 
 def test_get_codes_filter_standard(ukrdc3_session):
-    code_list = codes.get_codes(ukrdc3_session, coding_standard=["RR1+"]).all()
+    code_list = ukrdc3_session.scalars(codes.select_codes(coding_standard=["RR1+"])).all()
     assert {code.code for code in code_list} == {
         "TSF01",
         "TSF02",
     }
 
-    code_list = codes.get_codes(
-        ukrdc3_session, coding_standard=["CODING_STANDARD_1", "CODING_STANDARD_2"]
-    ).all()
+    code_list = ukrdc3_session.scalars(codes.select_codes(
+        coding_standard=["CODING_STANDARD_1", "CODING_STANDARD_2"]
+    )).all()
     assert {code.code for code in code_list} == {
         "CODE_1",
         "CODE_2",
@@ -34,7 +34,7 @@ def test_get_codes_filter_standard(ukrdc3_session):
 
 
 def test_get_codes_search_code(ukrdc3_session):
-    code_list = codes.get_codes(ukrdc3_session, search="CODE_").all()
+    code_list = ukrdc3_session.scalars(codes.select_codes(search="CODE_")).all()
     assert {code.code for code in code_list} == {
         "CODE_1",
         "CODE_2",
@@ -43,7 +43,7 @@ def test_get_codes_search_code(ukrdc3_session):
 
 
 def test_get_codes_search_description(ukrdc3_session):
-    code_list = codes.get_codes(ukrdc3_session, search="DESCRIPTION_").all()
+    code_list = ukrdc3_session.scalars(codes.select_codes(search="DESCRIPTION_")).all()
     assert {code.code for code in code_list} == {
         "CODE_1",
         "CODE_2",
@@ -52,16 +52,16 @@ def test_get_codes_search_description(ukrdc3_session):
 
 
 def test_get_codes_filter_standard_and_search(ukrdc3_session):
-    code_list = codes.get_codes(
-        ukrdc3_session, coding_standard=["RR1+"], search="1"
-    ).all()
+    code_list = ukrdc3_session.scalars(codes.select_codes(
+        coding_standard=["RR1+"], search="1"
+    )).all()
     assert {code.code for code in code_list} == {
         "TSF01",
     }
 
 
 def test_get_coding_standards(ukrdc3_session):
-    standards = codes.get_coding_standards(ukrdc3_session)
+    standards =codes.get_coding_standards(ukrdc3_session)
     assert set(standards) == {
         "NHS_DATA_DICTIONARY",
         "CODING_STANDARD_1",
@@ -71,54 +71,54 @@ def test_get_coding_standards(ukrdc3_session):
 
 
 def test_get_code_maps(ukrdc3_session):
-    code_maps = codes.get_code_maps(ukrdc3_session).all()
+    code_maps = ukrdc3_session.scalars(codes.select_code_maps()).all()
     assert len(code_maps) == 2
 
 
 def test_get_code_maps_filter_standard(ukrdc3_session):
-    code_maps = codes.get_code_maps(
-        ukrdc3_session, source_coding_standard=["CODING_STANDARD_1"]
-    ).all()
+    code_maps = ukrdc3_session.scalars(codes.select_code_maps(
+        source_coding_standard=["CODING_STANDARD_1"]
+    )).all()
     assert len(code_maps) == 1
     assert code_maps[0].source_code == "CODE_1"
     assert code_maps[0].destination_code == "CODE_2"
 
-    code_maps = codes.get_code_maps(
-        ukrdc3_session, source_coding_standard=["CODING_STANDARD_2"]
-    ).all()
+    code_maps = ukrdc3_session.scalars(codes.select_code_maps(
+        source_coding_standard=["CODING_STANDARD_2"]
+    )).all()
     assert len(code_maps) == 1
     assert code_maps[0].source_code == "CODE_2"
     assert code_maps[0].destination_code == "CODE_1"
 
-    code_maps = codes.get_code_maps(
-        ukrdc3_session, destination_coding_standard=["CODING_STANDARD_1"]
-    ).all()
+    code_maps = ukrdc3_session.scalars(codes.select_code_maps(
+        destination_coding_standard=["CODING_STANDARD_1"]
+    )).all()
     assert len(code_maps) == 1
     assert code_maps[0].source_code == "CODE_2"
     assert code_maps[0].destination_code == "CODE_1"
 
-    code_maps = codes.get_code_maps(
-        ukrdc3_session, destination_coding_standard=["CODING_STANDARD_2"]
-    ).all()
+    code_maps = ukrdc3_session.scalars(codes.select_code_maps(
+        destination_coding_standard=["CODING_STANDARD_2"]
+    )).all()
     assert len(code_maps) == 1
     assert code_maps[0].source_code == "CODE_1"
     assert code_maps[0].destination_code == "CODE_2"
 
 
 def test_get_code_maps_filter_code(ukrdc3_session):
-    code_maps = codes.get_code_maps(ukrdc3_session, source_code="CODE_1").all()
+    code_maps = ukrdc3_session.scalars(codes.select_code_maps(source_code="CODE_1")).all()
     assert len(code_maps) == 1
     assert code_maps[0].destination_code == "CODE_2"
 
-    code_maps = codes.get_code_maps(ukrdc3_session, source_code="CODE_2").all()
+    code_maps = ukrdc3_session.scalars(codes.select_code_maps(source_code="CODE_2")).all()
     assert len(code_maps) == 1
     assert code_maps[0].destination_code == "CODE_1"
 
-    code_maps = codes.get_code_maps(ukrdc3_session, destination_code="CODE_1").all()
+    code_maps = ukrdc3_session.scalars(codes.select_code_maps(destination_code="CODE_1")).all()
     assert len(code_maps) == 1
     assert code_maps[0].source_code == "CODE_2"
 
-    code_maps = codes.get_code_maps(ukrdc3_session, destination_code="CODE_2").all()
+    code_maps = ukrdc3_session.scalars(codes.select_code_maps(destination_code="CODE_2")).all()
     assert len(code_maps) == 1
     assert code_maps[0].source_code == "CODE_1"
 
@@ -149,7 +149,7 @@ def test_get_code(ukrdc3_session):
 
 
 def test_get_code_exclusions(ukrdc3_session):
-    exclusions = codes.get_code_exclusions(ukrdc3_session).all()
+    exclusions = ukrdc3_session.scalars(codes.select_code_exclusions()).all()
     assert {codeexc.code for codeexc in exclusions} == {
         "CODE_1",
         "CODE_2",
@@ -163,16 +163,16 @@ def test_get_code_exclusions(ukrdc3_session):
 
 
 def test_get_code_exclusions_filter_standard(ukrdc3_session):
-    exclusions = codes.get_code_exclusions(
-        ukrdc3_session, coding_standard=["CODING_STANDARD_1"]
-    ).all()
+    exclusions = ukrdc3_session.scalars(codes.select_code_exclusions(
+        coding_standard=["CODING_STANDARD_1"]
+    )).all()
     assert {codeexc.code for codeexc in exclusions} == {
         "CODE_1",
     }
 
 
 def test_get_code_exclusions_filter_system(ukrdc3_session):
-    exclusions = codes.get_code_exclusions(ukrdc3_session, system=["SYSTEM_1"]).all()
+    exclusions = ukrdc3_session.scalars(codes.select_code_exclusions(system=["SYSTEM_1"])).all()
     assert {codeexc.code for codeexc in exclusions} == {
         "CODE_1",
         "CODE_2",

--- a/tests/test_query/test_codes.py
+++ b/tests/test_query/test_codes.py
@@ -17,15 +17,17 @@ def test_get_codes(ukrdc3_session):
 
 
 def test_get_codes_filter_standard(ukrdc3_session):
-    code_list = ukrdc3_session.scalars(codes.select_codes(coding_standard=["RR1+"])).all()
+    code_list = ukrdc3_session.scalars(
+        codes.select_codes(coding_standard=["RR1+"])
+    ).all()
     assert {code.code for code in code_list} == {
         "TSF01",
         "TSF02",
     }
 
-    code_list = ukrdc3_session.scalars(codes.select_codes(
-        coding_standard=["CODING_STANDARD_1", "CODING_STANDARD_2"]
-    )).all()
+    code_list = ukrdc3_session.scalars(
+        codes.select_codes(coding_standard=["CODING_STANDARD_1", "CODING_STANDARD_2"])
+    ).all()
     assert {code.code for code in code_list} == {
         "CODE_1",
         "CODE_2",
@@ -52,16 +54,16 @@ def test_get_codes_search_description(ukrdc3_session):
 
 
 def test_get_codes_filter_standard_and_search(ukrdc3_session):
-    code_list = ukrdc3_session.scalars(codes.select_codes(
-        coding_standard=["RR1+"], search="1"
-    )).all()
+    code_list = ukrdc3_session.scalars(
+        codes.select_codes(coding_standard=["RR1+"], search="1")
+    ).all()
     assert {code.code for code in code_list} == {
         "TSF01",
     }
 
 
 def test_get_coding_standards(ukrdc3_session):
-    standards =codes.get_coding_standards(ukrdc3_session)
+    standards = codes.get_coding_standards(ukrdc3_session)
     assert set(standards) == {
         "NHS_DATA_DICTIONARY",
         "CODING_STANDARD_1",
@@ -76,49 +78,57 @@ def test_get_code_maps(ukrdc3_session):
 
 
 def test_get_code_maps_filter_standard(ukrdc3_session):
-    code_maps = ukrdc3_session.scalars(codes.select_code_maps(
-        source_coding_standard=["CODING_STANDARD_1"]
-    )).all()
+    code_maps = ukrdc3_session.scalars(
+        codes.select_code_maps(source_coding_standard=["CODING_STANDARD_1"])
+    ).all()
     assert len(code_maps) == 1
     assert code_maps[0].source_code == "CODE_1"
     assert code_maps[0].destination_code == "CODE_2"
 
-    code_maps = ukrdc3_session.scalars(codes.select_code_maps(
-        source_coding_standard=["CODING_STANDARD_2"]
-    )).all()
+    code_maps = ukrdc3_session.scalars(
+        codes.select_code_maps(source_coding_standard=["CODING_STANDARD_2"])
+    ).all()
     assert len(code_maps) == 1
     assert code_maps[0].source_code == "CODE_2"
     assert code_maps[0].destination_code == "CODE_1"
 
-    code_maps = ukrdc3_session.scalars(codes.select_code_maps(
-        destination_coding_standard=["CODING_STANDARD_1"]
-    )).all()
+    code_maps = ukrdc3_session.scalars(
+        codes.select_code_maps(destination_coding_standard=["CODING_STANDARD_1"])
+    ).all()
     assert len(code_maps) == 1
     assert code_maps[0].source_code == "CODE_2"
     assert code_maps[0].destination_code == "CODE_1"
 
-    code_maps = ukrdc3_session.scalars(codes.select_code_maps(
-        destination_coding_standard=["CODING_STANDARD_2"]
-    )).all()
+    code_maps = ukrdc3_session.scalars(
+        codes.select_code_maps(destination_coding_standard=["CODING_STANDARD_2"])
+    ).all()
     assert len(code_maps) == 1
     assert code_maps[0].source_code == "CODE_1"
     assert code_maps[0].destination_code == "CODE_2"
 
 
 def test_get_code_maps_filter_code(ukrdc3_session):
-    code_maps = ukrdc3_session.scalars(codes.select_code_maps(source_code="CODE_1")).all()
+    code_maps = ukrdc3_session.scalars(
+        codes.select_code_maps(source_code="CODE_1")
+    ).all()
     assert len(code_maps) == 1
     assert code_maps[0].destination_code == "CODE_2"
 
-    code_maps = ukrdc3_session.scalars(codes.select_code_maps(source_code="CODE_2")).all()
+    code_maps = ukrdc3_session.scalars(
+        codes.select_code_maps(source_code="CODE_2")
+    ).all()
     assert len(code_maps) == 1
     assert code_maps[0].destination_code == "CODE_1"
 
-    code_maps = ukrdc3_session.scalars(codes.select_code_maps(destination_code="CODE_1")).all()
+    code_maps = ukrdc3_session.scalars(
+        codes.select_code_maps(destination_code="CODE_1")
+    ).all()
     assert len(code_maps) == 1
     assert code_maps[0].source_code == "CODE_2"
 
-    code_maps = ukrdc3_session.scalars(codes.select_code_maps(destination_code="CODE_2")).all()
+    code_maps = ukrdc3_session.scalars(
+        codes.select_code_maps(destination_code="CODE_2")
+    ).all()
     assert len(code_maps) == 1
     assert code_maps[0].source_code == "CODE_1"
 
@@ -163,16 +173,18 @@ def test_get_code_exclusions(ukrdc3_session):
 
 
 def test_get_code_exclusions_filter_standard(ukrdc3_session):
-    exclusions = ukrdc3_session.scalars(codes.select_code_exclusions(
-        coding_standard=["CODING_STANDARD_1"]
-    )).all()
+    exclusions = ukrdc3_session.scalars(
+        codes.select_code_exclusions(coding_standard=["CODING_STANDARD_1"])
+    ).all()
     assert {codeexc.code for codeexc in exclusions} == {
         "CODE_1",
     }
 
 
 def test_get_code_exclusions_filter_system(ukrdc3_session):
-    exclusions = ukrdc3_session.scalars(codes.select_code_exclusions(system=["SYSTEM_1"])).all()
+    exclusions = ukrdc3_session.scalars(
+        codes.select_code_exclusions(system=["SYSTEM_1"])
+    ).all()
     assert {codeexc.code for codeexc in exclusions} == {
         "CODE_1",
         "CODE_2",

--- a/tests/test_query/test_common.py
+++ b/tests/test_query/test_common.py
@@ -4,7 +4,7 @@ from ukrdc_fastapi.query import common
 
 
 def test_person_belongs_to_units(jtrace_session):
-    person = jtrace_session.query(Person).get(1)
+    person = jtrace_session.get(Person, 1)
     assert common.person_belongs_to_units(person, ["TSF01"])
 
     assert common.person_belongs_to_units(person, ["TSF01", "MADE_UP_FACILITY"])

--- a/tests/test_query/test_delete.py
+++ b/tests/test_query/test_delete.py
@@ -12,7 +12,7 @@ from ukrdc_fastapi.query.delete import (
 
 
 def test_summarise_delete_pid_superuser(ukrdc3_session, jtrace_session):
-    record_to_delete = ukrdc3_session.query(PatientRecord).get("PYTEST03:PV:00000000A")
+    record_to_delete = ukrdc3_session.get(PatientRecord, "PYTEST03:PV:00000000A")
 
     summary_1 = summarise_delete_patientrecord(record_to_delete, jtrace_session)
     summary_2 = summarise_delete_patientrecord(record_to_delete, jtrace_session)
@@ -22,22 +22,22 @@ def test_summarise_delete_pid_superuser(ukrdc3_session, jtrace_session):
 
 
 def test_delete_pid_superuser(ukrdc3_session, jtrace_session):
-    record_to_delete = ukrdc3_session.query(PatientRecord).get("PYTEST03:PV:00000000A")
+    record_to_delete = ukrdc3_session.get(PatientRecord, "PYTEST03:PV:00000000A")
 
     summary = summarise_delete_patientrecord(record_to_delete, jtrace_session)
 
     # Assert all expected records exist
-    assert ukrdc3_session.query(PatientRecord).get("PYTEST03:PV:00000000A")
+    assert ukrdc3_session.get(PatientRecord, "PYTEST03:PV:00000000A")
     for person in summary.empi.persons:
-        assert jtrace_session.query(Person).get(person.id)
+        assert jtrace_session.get(Person, person.id)
     for master_record in summary.empi.master_records:
-        assert jtrace_session.query(MasterRecord).get(master_record.id)
+        assert jtrace_session.get(MasterRecord, master_record.id)
     for pidxref in summary.empi.pidxrefs:
-        assert jtrace_session.query(PidXRef).get(pidxref.id)
+        assert jtrace_session.get(PidXRef, pidxref.id)
     for work_item in summary.empi.work_items:
-        assert jtrace_session.query(WorkItem).get(work_item.id)
+        assert jtrace_session.get(WorkItem, work_item.id)
     for link_record in summary.empi.link_records:
-        assert jtrace_session.query(LinkRecord).get(link_record.id)
+        assert jtrace_session.get(LinkRecord, link_record.id)
 
     deleted = delete_patientrecord(
         record_to_delete, ukrdc3_session, jtrace_session, summary.hash
@@ -46,21 +46,21 @@ def test_delete_pid_superuser(ukrdc3_session, jtrace_session):
     assert deleted.hash == summary.hash
 
     # Assert all expected records have been deleted
-    assert not ukrdc3_session.query(PatientRecord).get("PYTEST03:PV:00000000A")
+    assert not ukrdc3_session.get(PatientRecord, "PYTEST03:PV:00000000A")
     for person in summary.empi.persons:
-        assert not jtrace_session.query(Person).get(person.id)
+        assert not jtrace_session.get(Person, person.id)
     for master_record in summary.empi.master_records:
-        assert not jtrace_session.query(MasterRecord).get(master_record.id)
+        assert not jtrace_session.get(MasterRecord, master_record.id)
     for pidxref in summary.empi.pidxrefs:
-        assert not jtrace_session.query(PidXRef).get(pidxref.id)
+        assert not jtrace_session.get(PidXRef, pidxref.id)
     for work_item in summary.empi.work_items:
-        assert not jtrace_session.query(WorkItem).get(work_item.id)
+        assert not jtrace_session.get(WorkItem, work_item.id)
     for link_record in summary.empi.link_records:
-        assert not jtrace_session.query(LinkRecord).get(link_record.id)
+        assert not jtrace_session.get(LinkRecord, link_record.id)
 
 
 def test_delete_pid_badhash(ukrdc3_session, jtrace_session):
-    record_to_delete = ukrdc3_session.query(PatientRecord).get("PYTEST03:PV:00000000A")
+    record_to_delete = ukrdc3_session.get(PatientRecord, "PYTEST03:PV:00000000A")
 
     with pytest.raises(ConfirmationError):
         delete_patientrecord(

--- a/tests/test_query/test_delete.py
+++ b/tests/test_query/test_delete.py
@@ -28,6 +28,8 @@ def test_delete_pid_superuser(ukrdc3_session, jtrace_session):
 
     # Assert all expected records exist
     assert ukrdc3_session.get(PatientRecord, "PYTEST03:PV:00000000A")
+
+    assert summary.empi
     for person in summary.empi.persons:
         assert jtrace_session.get(Person, person.id)
     for master_record in summary.empi.master_records:

--- a/tests/test_query/test_facilities.py
+++ b/tests/test_query/test_facilities.py
@@ -72,7 +72,7 @@ def test_get_facility(facility_code, ukrdc3_session, errorsdb_session):
 
 
 def test_get_facility_data_flow(ukrdc3_session, errorsdb_session):
-    facility_object = ukrdc3_session.query(Facility).get("TSF01")
+    facility_object = ukrdc3_session.get(Facility, "TSF01")
     facility_object.pkb_msg_exclusions = ["MDM_T02_CP", "MDM_T02_DOC"]
     ukrdc3_session.commit()
 

--- a/tests/test_query/test_facilities.py
+++ b/tests/test_query/test_facilities.py
@@ -15,8 +15,8 @@ from ukrdc_fastapi.query.facilities.errors import (
     query_patients_latest_errors,
 )
 from ukrdc_fastapi.query.facilities.reports import (
-    get_facility_report_cc001,
-    get_facility_report_pm001,
+    select_facility_report_cc001,
+    select_facility_report_pm001,
 )
 from ukrdc_fastapi.utils.cache import BasicCache, CacheKey
 
@@ -175,29 +175,29 @@ def test_get_facility_extracts(ukrdc3_session):
 
 
 def test_get_facility_report_cc001(ukrdc3_session):
-    report1 = get_facility_report_cc001(
+    report1 = ukrdc3_session.scalars(select_facility_report_cc001(
         ukrdc3_session,
         "TSF01",
-    ).all()
+    )).all()
 
     # Only 1 default test record has no treatments or memberships
     assert len(report1) == 1
     assert report1[0].pid == "PYTEST04:PV:00000000A"
 
-    report2 = get_facility_report_cc001(
+    report2 = ukrdc3_session.scalars(select_facility_report_cc001(
         ukrdc3_session,
         "TSF02",
-    ).all()
+    )).all()
 
     # TSF02 has no default test records with no treatments or memberships
     assert len(report2) == 0
 
 
 def test_get_facility_report_pm001(ukrdc3_session, jtrace_session):
-    report1 = get_facility_report_pm001(
+    report1 = ukrdc3_session.scalars(select_facility_report_pm001(
         ukrdc3_session,
         "TSF01",
-    ).all()
+    )).all()
 
     assert len(report1) == 2
     assert {record.pid for record in report1} == {
@@ -235,10 +235,10 @@ def test_get_facility_report_pm001(ukrdc3_session, jtrace_session):
 
     # Test again
 
-    report1 = get_facility_report_pm001(
+    report1 = ukrdc3_session.scalars(select_facility_report_pm001(
         ukrdc3_session,
         "TSF01",
-    ).all()
+    )).all()
 
     assert len(report1) == 1
     assert {record.pid for record in report1} == {"PYTEST04:PV:00000000A"}

--- a/tests/test_query/test_facilities.py
+++ b/tests/test_query/test_facilities.py
@@ -12,7 +12,7 @@ from ukrdc_fastapi.query.facilities import (
 )
 from ukrdc_fastapi.query.facilities.errors import (
     get_errors_history,
-    get_patients_latest_errors,
+    query_patients_latest_errors,
 )
 from ukrdc_fastapi.query.facilities.reports import (
     get_facility_report_cc001,
@@ -129,44 +129,40 @@ def test_get_facility_history_range(ukrdc3_session, errorsdb_session):
 
 
 def test_get_patients_latest_errors(ukrdc3_session, errorsdb_session):
-    messages = get_patients_latest_errors(
-        ukrdc3_session, errorsdb_session, "TSF01"
-    ).all()
+    messages = errorsdb_session.scalars(query_patients_latest_errors(
+        ukrdc3_session, "TSF01"
+    )).all()
     assert len(messages) == 1
     assert messages[0].id == 2
 
 
 def test_get_patients_latest_errors_channel(ukrdc3_session, errorsdb_session):
-    messages_1_1 = get_patients_latest_errors(
+    messages_1_1 = errorsdb_session.scalars(query_patients_latest_errors(
         ukrdc3_session,
-        errorsdb_session,
         "TSF01",
         channels=["00000000-0000-0000-0000-111111111111"],
-    ).all()
+    )).all()
     assert len(messages_1_1) == 1
 
-    messages_1_0 = get_patients_latest_errors(
+    messages_1_0 = errorsdb_session.scalars(query_patients_latest_errors(
         ukrdc3_session,
-        errorsdb_session,
         "TSF01",
         channels=["00000000-0000-0000-0000-000000000000"],
-    ).all()
+    )).all()
     assert len(messages_1_0) == 0
 
-    messages_2_1 = get_patients_latest_errors(
+    messages_2_1 = errorsdb_session.scalars(query_patients_latest_errors(
         ukrdc3_session,
-        errorsdb_session,
         "TSF02",
         channels=["00000000-0000-0000-0000-111111111111"],
-    ).all()
+    )).all()
     assert len(messages_2_1) == 0
 
-    messages_2_0 = get_patients_latest_errors(
+    messages_2_0 = errorsdb_session.scalars(query_patients_latest_errors(
         ukrdc3_session,
-        errorsdb_session,
         "TSF02",
         channels=["00000000-0000-0000-0000-000000000000"],
-    ).all()
+    )).all()
     assert len(messages_2_0) == 1
 
 

--- a/tests/test_query/test_facilities.py
+++ b/tests/test_query/test_facilities.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import pytest
+from sqlalchemy import select
 from ukrdc_sqla.ukrdc import Code, Facility, ProgramMembership
 
 from tests.conftest import UKRDCID_1
@@ -41,7 +42,7 @@ def test_get_facilities_cached(ukrdc3_session, errorsdb_session, redis_session):
     # Create the cache
     BasicCache(redis_session, CacheKey.FACILITIES_LIST).set(
         build_facilities_list(
-            ukrdc3_session.query(Facility), ukrdc3_session, errorsdb_session
+            select(Facility), ukrdc3_session, errorsdb_session
         )
     )
 

--- a/tests/test_query/test_facilities.py
+++ b/tests/test_query/test_facilities.py
@@ -41,9 +41,7 @@ def test_get_facilities(ukrdc3_session, errorsdb_session, redis_session):
 def test_get_facilities_cached(ukrdc3_session, errorsdb_session, redis_session):
     # Create the cache
     BasicCache(redis_session, CacheKey.FACILITIES_LIST).set(
-        build_facilities_list(
-            select(Facility), ukrdc3_session, errorsdb_session
-        )
+        build_facilities_list(select(Facility), ukrdc3_session, errorsdb_session)
     )
 
     all_facils = get_facilities(
@@ -130,40 +128,48 @@ def test_get_facility_history_range(ukrdc3_session, errorsdb_session):
 
 
 def test_get_patients_latest_errors(ukrdc3_session, errorsdb_session):
-    messages = errorsdb_session.scalars(query_patients_latest_errors(
-        ukrdc3_session, "TSF01"
-    )).all()
+    messages = errorsdb_session.scalars(
+        query_patients_latest_errors(ukrdc3_session, "TSF01")
+    ).all()
     assert len(messages) == 1
     assert messages[0].id == 2
 
 
 def test_get_patients_latest_errors_channel(ukrdc3_session, errorsdb_session):
-    messages_1_1 = errorsdb_session.scalars(query_patients_latest_errors(
-        ukrdc3_session,
-        "TSF01",
-        channels=["00000000-0000-0000-0000-111111111111"],
-    )).all()
+    messages_1_1 = errorsdb_session.scalars(
+        query_patients_latest_errors(
+            ukrdc3_session,
+            "TSF01",
+            channels=["00000000-0000-0000-0000-111111111111"],
+        )
+    ).all()
     assert len(messages_1_1) == 1
 
-    messages_1_0 = errorsdb_session.scalars(query_patients_latest_errors(
-        ukrdc3_session,
-        "TSF01",
-        channels=["00000000-0000-0000-0000-000000000000"],
-    )).all()
+    messages_1_0 = errorsdb_session.scalars(
+        query_patients_latest_errors(
+            ukrdc3_session,
+            "TSF01",
+            channels=["00000000-0000-0000-0000-000000000000"],
+        )
+    ).all()
     assert len(messages_1_0) == 0
 
-    messages_2_1 = errorsdb_session.scalars(query_patients_latest_errors(
-        ukrdc3_session,
-        "TSF02",
-        channels=["00000000-0000-0000-0000-111111111111"],
-    )).all()
+    messages_2_1 = errorsdb_session.scalars(
+        query_patients_latest_errors(
+            ukrdc3_session,
+            "TSF02",
+            channels=["00000000-0000-0000-0000-111111111111"],
+        )
+    ).all()
     assert len(messages_2_1) == 0
 
-    messages_2_0 = errorsdb_session.scalars(query_patients_latest_errors(
-        ukrdc3_session,
-        "TSF02",
-        channels=["00000000-0000-0000-0000-000000000000"],
-    )).all()
+    messages_2_0 = errorsdb_session.scalars(
+        query_patients_latest_errors(
+            ukrdc3_session,
+            "TSF02",
+            channels=["00000000-0000-0000-0000-000000000000"],
+        )
+    ).all()
     assert len(messages_2_0) == 1
 
 
@@ -176,29 +182,35 @@ def test_get_facility_extracts(ukrdc3_session):
 
 
 def test_get_facility_report_cc001(ukrdc3_session):
-    report1 = ukrdc3_session.scalars(select_facility_report_cc001(
-        ukrdc3_session,
-        "TSF01",
-    )).all()
+    report1 = ukrdc3_session.scalars(
+        select_facility_report_cc001(
+            ukrdc3_session,
+            "TSF01",
+        )
+    ).all()
 
     # Only 1 default test record has no treatments or memberships
     assert len(report1) == 1
     assert report1[0].pid == "PYTEST04:PV:00000000A"
 
-    report2 = ukrdc3_session.scalars(select_facility_report_cc001(
-        ukrdc3_session,
-        "TSF02",
-    )).all()
+    report2 = ukrdc3_session.scalars(
+        select_facility_report_cc001(
+            ukrdc3_session,
+            "TSF02",
+        )
+    ).all()
 
     # TSF02 has no default test records with no treatments or memberships
     assert len(report2) == 0
 
 
 def test_get_facility_report_pm001(ukrdc3_session, jtrace_session):
-    report1 = ukrdc3_session.scalars(select_facility_report_pm001(
-        ukrdc3_session,
-        "TSF01",
-    )).all()
+    report1 = ukrdc3_session.scalars(
+        select_facility_report_pm001(
+            ukrdc3_session,
+            "TSF01",
+        )
+    ).all()
 
     assert len(report1) == 2
     assert {record.pid for record in report1} == {
@@ -236,10 +248,12 @@ def test_get_facility_report_pm001(ukrdc3_session, jtrace_session):
 
     # Test again
 
-    report1 = ukrdc3_session.scalars(select_facility_report_pm001(
-        ukrdc3_session,
-        "TSF01",
-    )).all()
+    report1 = ukrdc3_session.scalars(
+        select_facility_report_pm001(
+            ukrdc3_session,
+            "TSF01",
+        )
+    ).all()
 
     assert len(report1) == 1
     assert {record.pid for record in report1} == {"PYTEST04:PV:00000000A"}

--- a/tests/test_query/test_masterrecords.py
+++ b/tests/test_query/test_masterrecords.py
@@ -4,41 +4,49 @@ from ukrdc_fastapi.query import masterrecords
 
 
 def test_masterrecord_related(jtrace_session):
-    records = jtrace_session.scalars(masterrecords.select_masterrecords_related_to_masterrecord(
-        jtrace_session.get(MasterRecord, 1), jtrace_session
-    ))
+    records = jtrace_session.scalars(
+        masterrecords.select_masterrecords_related_to_masterrecord(
+            jtrace_session.get(MasterRecord, 1), jtrace_session
+        )
+    )
 
     # Check MR3 is identified as related to MR1
     assert {record.id for record in records} == {1, 4, 101, 104}
 
 
 def test_masterrecord_related_exclude_self(jtrace_session):
-    records = jtrace_session.scalars(masterrecords.select_masterrecords_related_to_masterrecord(
-        jtrace_session.get(MasterRecord, 1), jtrace_session, exclude_self=True
-    ))
+    records = jtrace_session.scalars(
+        masterrecords.select_masterrecords_related_to_masterrecord(
+            jtrace_session.get(MasterRecord, 1), jtrace_session, exclude_self=True
+        )
+    )
 
     # Check MR3 is identified as related to MR1
     assert {record.id for record in records} == {4, 101, 104}
 
 
 def test_masterrecord_related_filter_nationalid_type(jtrace_session):
-    records = jtrace_session.scalars(masterrecords.select_masterrecords_related_to_masterrecord(
-        jtrace_session.get(MasterRecord, 1),
-        jtrace_session,
-        nationalid_type="UKRDC",
-    ))
+    records = jtrace_session.scalars(
+        masterrecords.select_masterrecords_related_to_masterrecord(
+            jtrace_session.get(MasterRecord, 1),
+            jtrace_session,
+            nationalid_type="UKRDC",
+        )
+    )
 
     # Check MR3 is identified as related to MR1
     assert {record.id for record in records} == {1, 4}
 
 
 def test_masterrecord_related_exclude_self_filter_nationalid_type(jtrace_session):
-    records = jtrace_session.scalars(masterrecords.select_masterrecords_related_to_masterrecord(
-        jtrace_session.get(MasterRecord, 1),
-        jtrace_session,
-        exclude_self=True,
-        nationalid_type="UKRDC",
-    ))
+    records = jtrace_session.scalars(
+        masterrecords.select_masterrecords_related_to_masterrecord(
+            jtrace_session.get(MasterRecord, 1),
+            jtrace_session,
+            exclude_self=True,
+            nationalid_type="UKRDC",
+        )
+    )
 
     # Check MR3 is identified as related to MR1
     assert {record.id for record in records} == {4}

--- a/tests/test_query/test_masterrecords.py
+++ b/tests/test_query/test_masterrecords.py
@@ -4,41 +4,41 @@ from ukrdc_fastapi.query import masterrecords
 
 
 def test_masterrecord_related(jtrace_session):
-    records = masterrecords.get_masterrecords_related_to_masterrecord(
-        jtrace_session.query(MasterRecord).get(1), jtrace_session
-    )
+    records = jtrace_session.scalars(masterrecords.select_masterrecords_related_to_masterrecord(
+        jtrace_session.get(MasterRecord, 1), jtrace_session
+    ))
 
     # Check MR3 is identified as related to MR1
     assert {record.id for record in records} == {1, 4, 101, 104}
 
 
 def test_masterrecord_related_exclude_self(jtrace_session):
-    records = masterrecords.get_masterrecords_related_to_masterrecord(
-        jtrace_session.query(MasterRecord).get(1), jtrace_session, exclude_self=True
-    )
+    records = jtrace_session.scalars(masterrecords.select_masterrecords_related_to_masterrecord(
+        jtrace_session.get(MasterRecord, 1), jtrace_session, exclude_self=True
+    ))
 
     # Check MR3 is identified as related to MR1
     assert {record.id for record in records} == {4, 101, 104}
 
 
 def test_masterrecord_related_filter_nationalid_type(jtrace_session):
-    records = masterrecords.get_masterrecords_related_to_masterrecord(
-        jtrace_session.query(MasterRecord).get(1),
+    records = jtrace_session.scalars(masterrecords.select_masterrecords_related_to_masterrecord(
+        jtrace_session.get(MasterRecord, 1),
         jtrace_session,
         nationalid_type="UKRDC",
-    )
+    ))
 
     # Check MR3 is identified as related to MR1
     assert {record.id for record in records} == {1, 4}
 
 
 def test_masterrecord_related_exclude_self_filter_nationalid_type(jtrace_session):
-    records = masterrecords.get_masterrecords_related_to_masterrecord(
-        jtrace_session.query(MasterRecord).get(1),
+    records = jtrace_session.scalars(masterrecords.select_masterrecords_related_to_masterrecord(
+        jtrace_session.get(MasterRecord, 1),
         jtrace_session,
         exclude_self=True,
         nationalid_type="UKRDC",
-    )
+    ))
 
     # Check MR3 is identified as related to MR1
     assert {record.id for record in records} == {4}

--- a/tests/test_query/test_memberships.py
+++ b/tests/test_query/test_memberships.py
@@ -8,7 +8,9 @@ from ukrdc_fastapi.query.memberships import (
 
 def test_get_active_memberships_for_patientrecord(ukrdc3_session):
     record = ukrdc3_session.get(PatientRecord, "PYTEST01:PV:00000000A")
-    memberships = ukrdc3_session.scalars(get_active_memberships_for_patientrecord(record)).all()
+    memberships = ukrdc3_session.scalars(
+        get_active_memberships_for_patientrecord(record)
+    ).all()
     assert len(memberships) == 1
     assert memberships[0].program_name == "PROGRAM_NAME_1"
 

--- a/tests/test_query/test_memberships.py
+++ b/tests/test_query/test_memberships.py
@@ -7,22 +7,22 @@ from ukrdc_fastapi.query.memberships import (
 
 
 def test_get_active_memberships_for_patientrecord(ukrdc3_session):
-    record = ukrdc3_session.query(PatientRecord).get("PYTEST01:PV:00000000A")
-    memberships = get_active_memberships_for_patientrecord(ukrdc3_session, record).all()
+    record = ukrdc3_session.get(PatientRecord, "PYTEST01:PV:00000000A")
+    memberships = ukrdc3_session.scalars(get_active_memberships_for_patientrecord(record)).all()
     assert len(memberships) == 1
     assert memberships[0].program_name == "PROGRAM_NAME_1"
 
 
 def test_record_has_active_membership_exists_active(ukrdc3_session):
-    record = ukrdc3_session.query(PatientRecord).get("PYTEST01:PV:00000000A")
+    record = ukrdc3_session.get(PatientRecord, "PYTEST01:PV:00000000A")
     assert record_has_active_membership(ukrdc3_session, record, "PROGRAM_NAME_1")
 
 
 def test_record_has_active_membership_exists_inactive(ukrdc3_session):
-    record = ukrdc3_session.query(PatientRecord).get("PYTEST01:PV:00000000A")
+    record = ukrdc3_session.get(PatientRecord, "PYTEST01:PV:00000000A")
     assert not record_has_active_membership(ukrdc3_session, record, "PROGRAM_NAME_2")
 
 
 def test_record_has_active_membership_notexists(ukrdc3_session):
-    record = ukrdc3_session.query(PatientRecord).get("PYTEST01:PV:00000000A")
+    record = ukrdc3_session.get(PatientRecord, "PYTEST01:PV:00000000A")
     assert not record_has_active_membership(ukrdc3_session, record, "PROGRAM_NAME_X")

--- a/tests/test_query/test_messages.py
+++ b/tests/test_query/test_messages.py
@@ -12,87 +12,107 @@ from ..utils import days_ago
 def test_get_messages(
     errorsdb_session,
 ):
-    all_msgs = errorsdb_session.scalars(messages.select_messages(since=days_ago(730))).all()
+    all_msgs = errorsdb_session.scalars(
+        messages.select_messages(since=days_ago(730))
+    ).all()
     # Superuser should see all error messages
     assert {error.id for error in all_msgs} == {1, 2, 3}
 
 
 def test_get_errors(errorsdb_session):
-    all_msgs = errorsdb_session.scalars(messages.select_messages(
-        statuses=["ERROR"], since=days_ago(730)
-    )).all()
+    all_msgs = errorsdb_session.scalars(
+        messages.select_messages(statuses=["ERROR"], since=days_ago(730))
+    ).all()
     # Superuser should see all error messages
     assert {error.id for error in all_msgs} == {2, 3}
 
 
 def test_get_errors_until(errorsdb_session):
-    all_errors = errorsdb_session.scalars(messages.select_messages(
-        since=days_ago(730),
-        until=days_ago(3),
-    )).all()
+    all_errors = errorsdb_session.scalars(
+        messages.select_messages(
+            since=days_ago(730),
+            until=days_ago(3),
+        )
+    ).all()
     assert {error.id for error in all_errors} == {3}
 
 
 def test_get_errors_facility(errorsdb_session):
-    all_errors = errorsdb_session.scalars(messages.select_messages(
-        since=days_ago(730),
-        facility="TSF02",
-    )).all()
+    all_errors = errorsdb_session.scalars(
+        messages.select_messages(
+            since=days_ago(730),
+            facility="TSF02",
+        )
+    ).all()
     assert {error.id for error in all_errors} == {3}
 
 
 def test_get_errors_channel(errorsdb_session):
-    all_errors = errorsdb_session.scalars(messages.select_messages(
-        since=days_ago(730),
-        channels=["00000000-0000-0000-0000-111111111111"],
-    )).all()
+    all_errors = errorsdb_session.scalars(
+        messages.select_messages(
+            since=days_ago(730),
+            channels=["00000000-0000-0000-0000-111111111111"],
+        )
+    ).all()
     assert {error.id for error in all_errors} == {2}
 
 
 def test_get_errors_multiple_channels(errorsdb_session):
-    all_errors = errorsdb_session.scalars(messages.select_messages(
-        since=days_ago(730),
-        channels=[
-            "00000000-0000-0000-0000-000000000000",
-            "00000000-0000-0000-0000-111111111111",
-        ],
-    )).all()
+    all_errors = errorsdb_session.scalars(
+        messages.select_messages(
+            since=days_ago(730),
+            channels=[
+                "00000000-0000-0000-0000-000000000000",
+                "00000000-0000-0000-0000-111111111111",
+            ],
+        )
+    ).all()
     assert {error.id for error in all_errors} == {1, 2, 3}
 
 
 def test_get_messages_nis(errorsdb_session):
-    all_msgs = errorsdb_session.scalars(messages.select_messages(since=days_ago(730), nis=[NI_1])).all()
+    all_msgs = errorsdb_session.scalars(
+        messages.select_messages(since=days_ago(730), nis=[NI_1])
+    ).all()
     assert {error.id for error in all_msgs} == {1, 2}
 
 
 def test_get_masterrecord_messages(errorsdb_session, jtrace_session):
-    error_list = errorsdb_session.scalars(messages.select_messages_related_to_masterrecord(
-        jtrace_session.get(MasterRecord, 1), jtrace_session
-    )).all()
+    error_list = errorsdb_session.scalars(
+        messages.select_messages_related_to_masterrecord(
+            jtrace_session.get(MasterRecord, 1), jtrace_session
+        )
+    ).all()
     assert {error.id for error in error_list} == {1, 2}
 
 
 def test_get_masterrecord_errors(errorsdb_session, jtrace_session):
-    error_list = errorsdb_session.scalars(messages.select_messages_related_to_masterrecord(
-        jtrace_session.get(MasterRecord, 1),
-        jtrace_session,
-        statuses=["ERROR"],
-    )).all()
+    error_list = errorsdb_session.scalars(
+        messages.select_messages_related_to_masterrecord(
+            jtrace_session.get(MasterRecord, 1),
+            jtrace_session,
+            statuses=["ERROR"],
+        )
+    ).all()
     assert {error.id for error in error_list} == {2}
 
 
 def test_get_patientrecord_messages(errorsdb_session, ukrdc3_session):
-    error_list = errorsdb_session.scalars(messages.select_messages_related_to_patientrecord(
-        ukrdc3_session.get(PatientRecord, PID_1)
-    )).all()
+    error_list = errorsdb_session.scalars(
+        messages.select_messages_related_to_patientrecord(
+            ukrdc3_session.get(PatientRecord, PID_1)
+        )
+    ).all()
     assert {error.id for error in error_list} == {1, 2}
 
 
 def test_get_patientrecord_errors(errorsdb_session, ukrdc3_session):
-    error_list = errorsdb_session.scalars(messages.select_messages_related_to_patientrecord(
-        ukrdc3_session.get(PatientRecord, PID_1),
-        statuses=["ERROR"],
-    )).all()
+    error_list = errorsdb_session.scalars(
+        messages.select_messages_related_to_patientrecord(
+            ukrdc3_session.get(PatientRecord, PID_1),
+            statuses=["ERROR"],
+        )
+    ).all()
     assert {error.id for error in error_list} == {2}
 
 

--- a/tests/test_query/test_messages.py
+++ b/tests/test_query/test_messages.py
@@ -12,99 +12,93 @@ from ..utils import days_ago
 def test_get_messages(
     errorsdb_session,
 ):
-    all_msgs = messages.get_messages(errorsdb_session, since=days_ago(730))
+    all_msgs = errorsdb_session.scalars(messages.select_messages(since=days_ago(730))).all()
     # Superuser should see all error messages
     assert {error.id for error in all_msgs} == {1, 2, 3}
 
 
 def test_get_errors(errorsdb_session):
-    all_msgs = messages.get_messages(
-        errorsdb_session, statuses=["ERROR"], since=days_ago(730)
-    )
+    all_msgs = errorsdb_session.scalars(messages.select_messages(
+        statuses=["ERROR"], since=days_ago(730)
+    )).all()
     # Superuser should see all error messages
     assert {error.id for error in all_msgs} == {2, 3}
 
 
 def test_get_errors_until(errorsdb_session):
-    all_errors = messages.get_messages(
-        errorsdb_session,
+    all_errors = errorsdb_session.scalars(messages.select_messages(
         since=days_ago(730),
         until=days_ago(3),
-    )
+    )).all()
     assert {error.id for error in all_errors} == {3}
 
 
 def test_get_errors_facility(errorsdb_session):
-    all_errors = messages.get_messages(
-        errorsdb_session,
+    all_errors = errorsdb_session.scalars(messages.select_messages(
         since=days_ago(730),
         facility="TSF02",
-    )
+    )).all()
     assert {error.id for error in all_errors} == {3}
 
 
 def test_get_errors_channel(errorsdb_session):
-    all_errors = messages.get_messages(
-        errorsdb_session,
+    all_errors = errorsdb_session.scalars(messages.select_messages(
         since=days_ago(730),
         channels=["00000000-0000-0000-0000-111111111111"],
-    )
+    )).all()
     assert {error.id for error in all_errors} == {2}
 
 
 def test_get_errors_multiple_channels(errorsdb_session):
-    all_errors = messages.get_messages(
-        errorsdb_session,
+    all_errors = errorsdb_session.scalars(messages.select_messages(
         since=days_ago(730),
         channels=[
             "00000000-0000-0000-0000-000000000000",
             "00000000-0000-0000-0000-111111111111",
         ],
-    )
+    )).all()
     assert {error.id for error in all_errors} == {1, 2, 3}
 
 
 def test_get_messages_nis(errorsdb_session):
-    all_msgs = messages.get_messages(errorsdb_session, since=days_ago(730), nis=[NI_1])
+    all_msgs = errorsdb_session.scalars(messages.select_messages(since=days_ago(730), nis=[NI_1])).all()
     assert {error.id for error in all_msgs} == {1, 2}
 
 
 def test_get_masterrecord_messages(errorsdb_session, jtrace_session):
-    error_list = messages.get_messages_related_to_masterrecord(
-        jtrace_session.query(MasterRecord).get(1), errorsdb_session, jtrace_session
-    ).all()
+    error_list = errorsdb_session.scalars(messages.select_messages_related_to_masterrecord(
+        jtrace_session.get(MasterRecord, 1), jtrace_session
+    )).all()
     assert {error.id for error in error_list} == {1, 2}
 
 
 def test_get_masterrecord_errors(errorsdb_session, jtrace_session):
-    error_list = messages.get_messages_related_to_masterrecord(
-        jtrace_session.query(MasterRecord).get(1),
-        errorsdb_session,
+    error_list = errorsdb_session.scalars(messages.select_messages_related_to_masterrecord(
+        jtrace_session.get(MasterRecord, 1),
         jtrace_session,
         statuses=["ERROR"],
-    ).all()
+    )).all()
     assert {error.id for error in error_list} == {2}
 
 
 def test_get_patientrecord_messages(errorsdb_session, ukrdc3_session):
-    error_list = messages.get_messages_related_to_patientrecord(
-        ukrdc3_session.query(PatientRecord).get(PID_1), errorsdb_session
-    ).all()
+    error_list = errorsdb_session.scalars(messages.select_messages_related_to_patientrecord(
+        ukrdc3_session.get(PatientRecord, PID_1)
+    )).all()
     assert {error.id for error in error_list} == {1, 2}
 
 
 def test_get_patientrecord_errors(errorsdb_session, ukrdc3_session):
-    error_list = messages.get_messages_related_to_patientrecord(
-        ukrdc3_session.query(PatientRecord).get(PID_1),
-        errorsdb_session,
+    error_list = errorsdb_session.scalars(messages.select_messages_related_to_patientrecord(
+        ukrdc3_session.get(PatientRecord, PID_1),
         statuses=["ERROR"],
-    ).all()
+    )).all()
     assert {error.id for error in error_list} == {2}
 
 
 @pytest.mark.asyncio
 async def test_get_message_source(mirth_session, errorsdb_session, httpx_session):
-    message = errorsdb_session.query(Message).get(1)
+    message = errorsdb_session.get(Message, 1)
     source = await messages.get_message_source(message, mirth_session)
     assert (
         source.content

--- a/tests/test_query/test_mirth/test_export.py
+++ b/tests/test_query/test_mirth/test_export.py
@@ -6,7 +6,7 @@ from ukrdc_fastapi.query.mirth import export
 
 async def test_export_all_to_pv(ukrdc3_session, redis_session, mirth_session):
     response = await export.export_all_to_pv(
-        ukrdc3_session.query(PatientRecord).get("PYTEST01:PV:00000000A"),
+        ukrdc3_session.get(PatientRecord, "PYTEST01:PV:00000000A"),
         mirth_session,
         redis_session,
     )
@@ -19,7 +19,7 @@ async def test_export_all_to_pv(ukrdc3_session, redis_session, mirth_session):
 
 async def test_record_export_tests(ukrdc3_session, redis_session, mirth_session):
     response = await export.export_tests_to_pv(
-        ukrdc3_session.query(PatientRecord).get("PYTEST01:PV:00000000A"),
+        ukrdc3_session.get(PatientRecord, "PYTEST01:PV:00000000A"),
         mirth_session,
         redis_session,
     )
@@ -32,7 +32,7 @@ async def test_record_export_tests(ukrdc3_session, redis_session, mirth_session)
 
 async def test_record_export_docs(ukrdc3_session, redis_session, mirth_session):
     response = await export.export_docs_to_pv(
-        ukrdc3_session.query(PatientRecord).get("PYTEST01:PV:00000000A"),
+        ukrdc3_session.get(PatientRecord, "PYTEST01:PV:00000000A"),
         mirth_session,
         redis_session,
     )
@@ -45,7 +45,7 @@ async def test_record_export_docs(ukrdc3_session, redis_session, mirth_session):
 
 async def test_record_export_radar(ukrdc3_session, redis_session, mirth_session):
     response = await export.export_all_to_radar(
-        ukrdc3_session.query(PatientRecord).get("PYTEST01:PV:00000000A"),
+        ukrdc3_session.get(PatientRecord, "PYTEST01:PV:00000000A"),
         mirth_session,
         redis_session,
     )
@@ -71,7 +71,7 @@ async def test_record_export_pkb(ukrdc3_session, redis_session, mirth_session):
 
     # Iterate over each message response
     for response in await export.export_all_to_pkb(
-        ukrdc3_session.query(PatientRecord).get(PID_1),
+        ukrdc3_session.get(PatientRecord, PID_1),
         ukrdc3_session,
         mirth_session,
         redis_session,

--- a/tests/test_query/test_mirth/test_export_restrictions.py
+++ b/tests/test_query/test_mirth/test_export_restrictions.py
@@ -65,7 +65,7 @@ async def test_export_all_to_pv_forbidden(
 
     with pytest.raises(RecordTypeError):
         await export.export_all_to_pv(
-            ukrdc3_session.query(PatientRecord).get(TEST_PID),
+            ukrdc3_session.get(PatientRecord, TEST_PID),
             mirth_session,
             redis_session,
         )
@@ -86,7 +86,7 @@ async def test_record_export_tests_forbidden(
 
     with pytest.raises(RecordTypeError):
         await export.export_tests_to_pv(
-            ukrdc3_session.query(PatientRecord).get(TEST_PID),
+            ukrdc3_session.get(PatientRecord, TEST_PID),
             mirth_session,
             redis_session,
         )
@@ -107,7 +107,7 @@ async def test_record_export_docs_forbidden(
 
     with pytest.raises(RecordTypeError):
         await export.export_docs_to_pv(
-            ukrdc3_session.query(PatientRecord).get(TEST_PID),
+            ukrdc3_session.get(PatientRecord, TEST_PID),
             mirth_session,
             redis_session,
         )
@@ -128,7 +128,7 @@ async def test_record_export_radar_forbidden(
 
     with pytest.raises(RecordTypeError):
         await export.export_all_to_radar(
-            ukrdc3_session.query(PatientRecord).get(TEST_PID),
+            ukrdc3_session.get(PatientRecord, TEST_PID),
             mirth_session,
             redis_session,
         )
@@ -149,7 +149,7 @@ async def test_record_export_pkb_forbidden(
 
     with pytest.raises(RecordTypeError):
         await export.export_all_to_pkb(
-            ukrdc3_session.query(PatientRecord).get(TEST_PID),
+            ukrdc3_session.get(PatientRecord,TEST_PID),
             ukrdc3_session,
             mirth_session,
             redis_session,

--- a/tests/test_query/test_mirth/test_export_restrictions.py
+++ b/tests/test_query/test_mirth/test_export_restrictions.py
@@ -149,7 +149,7 @@ async def test_record_export_pkb_forbidden(
 
     with pytest.raises(RecordTypeError):
         await export.export_all_to_pkb(
-            ukrdc3_session.get(PatientRecord,TEST_PID),
+            ukrdc3_session.get(PatientRecord, TEST_PID),
             ukrdc3_session,
             mirth_session,
             redis_session,

--- a/tests/test_query/test_mirth/test_rda.py
+++ b/tests/test_query/test_mirth/test_rda.py
@@ -10,7 +10,7 @@ from ukrdc_fastapi.schemas.patientrecord.patient import AddressSchema, NameSchem
 @pytest.mark.asyncio
 async def test_create_pkb_membership(ukrdc3_session, redis_session, mirth_session):
     PID_1 = "PYTEST01:PV:00000000A"
-    record = ukrdc3_session.query(PatientRecord).get(PID_1)
+    record = ukrdc3_session.get(PatientRecord, PID_1)
 
     response = await rda.update_patient_demographics(
         record,

--- a/tests/test_query/test_mirth/test_unlink.py
+++ b/tests/test_query/test_mirth/test_unlink.py
@@ -9,8 +9,8 @@ async def test_unlink_person_from_master_record(
     jtrace_session, redis_session, mirth_session, superuser
 ):
     response = await unlink_person_from_master_record(
-        jtrace_session.query(Person).get(4),
-        jtrace_session.query(MasterRecord).get(1),
+        jtrace_session.get(Person, 4),
+        jtrace_session.get(MasterRecord, 1),
         "comment",
         "user",
         jtrace_session,

--- a/tests/test_query/test_mirth/test_workitems.py
+++ b/tests/test_query/test_mirth/test_workitems.py
@@ -7,7 +7,7 @@ from ukrdc_fastapi.query.mirth import workitems
 @pytest.mark.asyncio
 async def test_update_workitem(jtrace_session, redis_session, mirth_session):
     response = await workitems.update_workitem(
-        jtrace_session.query(WorkItem).get(1),
+        jtrace_session.get(WorkItem, 1),
         mirth_session,
         redis_session,
         "TEST@UKRDC_FASTAPI",

--- a/tests/test_query/test_patientrecords/test_patientrecords.py
+++ b/tests/test_query/test_patientrecords/test_patientrecords.py
@@ -84,9 +84,10 @@ def _create_related_records(ukrdc3_session, jtrace_session):
 def test_get_patientrecords_related_to_masterrecord(ukrdc3_session, jtrace_session):
     _create_related_records(ukrdc3_session, jtrace_session)
 
-    records = patientrecords.get_patientrecords_related_to_masterrecord(
-        jtrace_session.query(MasterRecord).get(105), ukrdc3_session, jtrace_session
+    stmt = patientrecords.select_patientrecords_related_to_masterrecord(
+        jtrace_session.get(MasterRecord, 105), jtrace_session
     )
+    records = ukrdc3_session.scalars(stmt).all()
 
     assert {record.pid for record in records} == {
         "PYTEST02:TPR:TEST1",
@@ -99,9 +100,10 @@ def test_get_patientrecords_related_to_masterrecord(ukrdc3_session, jtrace_sessi
 def test_get_patientrecords_related_to_ni(ukrdc3_session, jtrace_session):
     _create_related_records(ukrdc3_session, jtrace_session)
 
-    records = patientrecords.get_patientrecords_related_to_ni(
-        "888888885", ukrdc3_session
+    stmt = patientrecords.select_patientrecords_related_to_ni(
+        "888888885"
     )
+    records = ukrdc3_session.scalars(stmt).all()
 
     assert {record.pid for record in records} == {
         # The original

--- a/tests/test_query/test_patientrecords/test_patientrecords.py
+++ b/tests/test_query/test_patientrecords/test_patientrecords.py
@@ -100,9 +100,7 @@ def test_get_patientrecords_related_to_masterrecord(ukrdc3_session, jtrace_sessi
 def test_get_patientrecords_related_to_ni(ukrdc3_session, jtrace_session):
     _create_related_records(ukrdc3_session, jtrace_session)
 
-    stmt = patientrecords.select_patientrecords_related_to_ni(
-        "888888885"
-    )
+    stmt = patientrecords.select_patientrecords_related_to_ni("888888885")
     records = ukrdc3_session.scalars(stmt).all()
 
     assert {record.pid for record in records} == {

--- a/tests/test_query/test_patientrecords/test_patientrecords_diagnoses.py
+++ b/tests/test_query/test_patientrecords/test_patientrecords_diagnoses.py
@@ -96,7 +96,7 @@ def _add_extra_diagnoses(session):
 
 def test_get_patient_diagnosis(ukrdc3_session):
     _add_extra_diagnoses(ukrdc3_session)
-    record = ukrdc3_session.query(PatientRecord).get(PID_1)
+    record = ukrdc3_session.get(PatientRecord, PID_1)
 
     diagnoses = get_patient_diagnosis(record, ukrdc3_session)
 
@@ -109,7 +109,7 @@ def test_get_patient_diagnosis(ukrdc3_session):
 
 def test_get_patient_renal_diagnosis(ukrdc3_session):
     _add_extra_diagnoses(ukrdc3_session)
-    record = ukrdc3_session.query(PatientRecord).get(PID_1)
+    record = ukrdc3_session.get(PatientRecord, PID_1)
 
     renal_diagnoses = get_patient_renal_diagnosis(record, ukrdc3_session)
 
@@ -121,7 +121,7 @@ def test_get_patient_renal_diagnosis(ukrdc3_session):
 
 def test_get_patient_cause_of_death(ukrdc3_session):
     _add_extra_diagnoses(ukrdc3_session)
-    record = ukrdc3_session.query(PatientRecord).get(PID_1)
+    record = ukrdc3_session.get(PatientRecord, PID_1)
 
     cause_of_death = get_patient_cause_of_death(record, ukrdc3_session)
 

--- a/tests/test_query/test_patientrecords/test_patientrecords_diagnoses.py
+++ b/tests/test_query/test_patientrecords/test_patientrecords_diagnoses.py
@@ -98,7 +98,7 @@ def test_get_patient_diagnosis(ukrdc3_session):
     _add_extra_diagnoses(ukrdc3_session)
     record = ukrdc3_session.query(PatientRecord).get(PID_1)
 
-    diagnoses = get_patient_diagnosis(record)
+    diagnoses = get_patient_diagnosis(record, ukrdc3_session)
 
     # Check all rows are returned
     assert len(diagnoses) == 2
@@ -111,7 +111,7 @@ def test_get_patient_renal_diagnosis(ukrdc3_session):
     _add_extra_diagnoses(ukrdc3_session)
     record = ukrdc3_session.query(PatientRecord).get(PID_1)
 
-    renal_diagnoses = get_patient_renal_diagnosis(record)
+    renal_diagnoses = get_patient_renal_diagnosis(record, ukrdc3_session)
 
     # Check all rows are returned
     assert len(renal_diagnoses) == 1
@@ -123,7 +123,7 @@ def test_get_patient_cause_of_death(ukrdc3_session):
     _add_extra_diagnoses(ukrdc3_session)
     record = ukrdc3_session.query(PatientRecord).get(PID_1)
 
-    cause_of_death = get_patient_cause_of_death(record)
+    cause_of_death = get_patient_cause_of_death(record, ukrdc3_session)
 
     # Check all rows are returned
     assert len(cause_of_death) == 1

--- a/tests/test_query/test_users.py
+++ b/tests/test_query/test_users.py
@@ -29,7 +29,5 @@ def test_update_user_preferences_placeholder(users_session, superuser):
     assert prefs.placeholder is True
 
     # Ensure the update preference has been committed to the database
-    db_placeholder = users_session.query(UserPreference).get(
-        (superuser.id, "placeholder")
-    )
+    db_placeholder = users_session.get(UserPreference, (superuser.id, "placeholder"))
     assert db_placeholder

--- a/tests/test_query/test_workitems.py
+++ b/tests/test_query/test_workitems.py
@@ -18,34 +18,46 @@ def test_get_workitems_facility(jtrace_session, superuser):
 
 
 def test_get_workitems_statuses(jtrace_session):
-    all_items = jtrace_session.scalars(workitems.select_workitems(statuses=[1, 3])).all()
+    all_items = jtrace_session.scalars(
+        workitems.select_workitems(statuses=[1, 3])
+    ).all()
     assert {item.id for item in all_items} == {1, 2, 3, 4}
 
 
 def test_get_workitems_since(jtrace_session):
-    all_items = jtrace_session.scalars(workitems.select_workitems(since=days_ago(1))).all()
+    all_items = jtrace_session.scalars(
+        workitems.select_workitems(since=days_ago(1))
+    ).all()
     assert {item.id for item in all_items} == {2, 3}
 
 
 def test_get_workitems_until(jtrace_session):
-    all_items = jtrace_session.scalars(workitems.select_workitems(until=days_ago(2))).all()
+    all_items = jtrace_session.scalars(
+        workitems.select_workitems(until=days_ago(2))
+    ).all()
     assert {item.id for item in all_items} == {1}
 
 
 def test_get_workitems_masterid(jtrace_session):
-    all_items = jtrace_session.scalars(workitems.select_workitems(master_id=[104])).all()
+    all_items = jtrace_session.scalars(
+        workitems.select_workitems(master_id=[104])
+    ).all()
     assert {item.id for item in all_items} == {1, 2}
 
 
 def test_get_workitem_related(jtrace_session):
-    related = jtrace_session.scalars(workitems.select_workitems_related_to_workitem(
-        jtrace_session.get(WorkItem, 1), jtrace_session
-    )).all()
+    related = jtrace_session.scalars(
+        workitems.select_workitems_related_to_workitem(
+            jtrace_session.get(WorkItem, 1), jtrace_session
+        )
+    ).all()
     assert {item.id for item in related} == {2, 3, 4}
 
-    related = jtrace_session.scalars(workitems.select_workitems_related_to_workitem(
-        jtrace_session.get(WorkItem, 2), jtrace_session
-    )).all()
+    related = jtrace_session.scalars(
+        workitems.select_workitems_related_to_workitem(
+            jtrace_session.get(WorkItem, 2), jtrace_session
+        )
+    ).all()
     assert {item.id for item in related} == {1, 3, 4}
 
 
@@ -76,11 +88,12 @@ def test_get_extended_workitem_superuser(jtrace_session):
     jtrace_session.add(link_record_999)
     jtrace_session.commit()
 
-    record = workitems.extend_workitem(
-        jtrace_session.get(WorkItem, 1), jtrace_session
-    )
+    record = workitems.extend_workitem(jtrace_session.get(WorkItem, 1), jtrace_session)
     assert record
     assert record.id == 1
+
+    assert record.incoming.person
+    assert record.destination.master_record
 
     in_person = record.incoming.person.id
     in_masters = [master.id for master in record.incoming.master_records]
@@ -94,21 +107,27 @@ def test_get_extended_workitem_superuser(jtrace_session):
 
 
 def test_get_workitem_collection(jtrace_session):
-    collection = jtrace_session.scalars(workitems.select_workitem_collection(
-        jtrace_session.get(WorkItem, 1), jtrace_session
-    )).all()
+    collection = jtrace_session.scalars(
+        workitems.select_workitem_collection(
+            jtrace_session.get(WorkItem, 1), jtrace_session
+        )
+    ).all()
     assert {item.id for item in collection} == set()
 
-    collection = jtrace_session.scalars(workitems.select_workitem_collection(
-        jtrace_session.get(WorkItem, 2), jtrace_session
-    )).all()
+    collection = jtrace_session.scalars(
+        workitems.select_workitem_collection(
+            jtrace_session.get(WorkItem, 2), jtrace_session
+        )
+    ).all()
     assert {item.id for item in collection} == {3, 4}
 
 
 def test_get_workitems_related_to_message(jtrace_session, errorsdb_session):
-    related = jtrace_session.scalars(workitems.select_workitems_related_to_message(
-        errorsdb_session.get(Message, 3), jtrace_session
-    )).all()
+    related = jtrace_session.scalars(
+        workitems.select_workitems_related_to_message(
+            errorsdb_session.get(Message, 3), jtrace_session
+        )
+    ).all()
     assert {item.id for item in related} == {3}
 
 

--- a/tests/test_query/test_workitems.py
+++ b/tests/test_query/test_workitems.py
@@ -8,44 +8,44 @@ from ukrdc_fastapi.query import workitems
 
 
 def test_get_workitems_superuser(jtrace_session):
-    all_items = workitems.get_workitems(jtrace_session)
+    all_items = jtrace_session.scalars(workitems.select_workitems()).all()
     assert {item.id for item in all_items} == {1, 2, 3}
 
 
 def test_get_workitems_facility(jtrace_session, superuser):
-    all_items = workitems.get_workitems(jtrace_session, statuses=[3])
+    all_items = jtrace_session.scalars(workitems.select_workitems(statuses=[3])).all()
     assert {item.id for item in all_items} == {4}
 
 
 def test_get_workitems_statuses(jtrace_session):
-    all_items = workitems.get_workitems(jtrace_session, statuses=[1, 3])
+    all_items = jtrace_session.scalars(workitems.select_workitems(statuses=[1, 3])).all()
     assert {item.id for item in all_items} == {1, 2, 3, 4}
 
 
 def test_get_workitems_since(jtrace_session):
-    all_items = workitems.get_workitems(jtrace_session, since=days_ago(1))
+    all_items = jtrace_session.scalars(workitems.select_workitems(since=days_ago(1))).all()
     assert {item.id for item in all_items} == {2, 3}
 
 
 def test_get_workitems_until(jtrace_session):
-    all_items = workitems.get_workitems(jtrace_session, until=days_ago(2))
+    all_items = jtrace_session.scalars(workitems.select_workitems(until=days_ago(2))).all()
     assert {item.id for item in all_items} == {1}
 
 
 def test_get_workitems_masterid(jtrace_session):
-    all_items = workitems.get_workitems(jtrace_session, master_id=[104])
+    all_items = jtrace_session.scalars(workitems.select_workitems(master_id=[104])).all()
     assert {item.id for item in all_items} == {1, 2}
 
 
 def test_get_workitem_related(jtrace_session):
-    related = workitems.get_workitems_related_to_workitem(
+    related = jtrace_session.scalars(workitems.select_workitems_related_to_workitem(
         jtrace_session.query(WorkItem).get(1), jtrace_session
-    )
+    )).all()
     assert {item.id for item in related} == {2, 3, 4}
 
-    related = workitems.get_workitems_related_to_workitem(
+    related = jtrace_session.scalars(workitems.select_workitems_related_to_workitem(
         jtrace_session.query(WorkItem).get(2), jtrace_session
-    )
+    )).all()
     assert {item.id for item in related} == {1, 3, 4}
 
 
@@ -94,21 +94,21 @@ def test_get_extended_workitem_superuser(jtrace_session):
 
 
 def test_get_workitem_collection(jtrace_session):
-    collection = workitems.get_workitem_collection(
+    collection = jtrace_session.scalars(workitems.select_workitem_collection(
         jtrace_session.query(WorkItem).get(1), jtrace_session
-    )
+    )).all()
     assert {item.id for item in collection} == set()
 
-    collection = workitems.get_workitem_collection(
+    collection = jtrace_session.scalars(workitems.select_workitem_collection(
         jtrace_session.query(WorkItem).get(2), jtrace_session
-    )
+    )).all()
     assert {item.id for item in collection} == {3, 4}
 
 
 def test_get_workitems_related_to_message(jtrace_session, errorsdb_session):
-    related = workitems.get_workitems_related_to_message(
+    related = jtrace_session.scalars(workitems.select_workitems_related_to_message(
         errorsdb_session.query(Message).get(3), jtrace_session
-    )
+    )).all()
     assert {item.id for item in related} == {3}
 
 

--- a/tests/test_query/test_workitems.py
+++ b/tests/test_query/test_workitems.py
@@ -39,12 +39,12 @@ def test_get_workitems_masterid(jtrace_session):
 
 def test_get_workitem_related(jtrace_session):
     related = jtrace_session.scalars(workitems.select_workitems_related_to_workitem(
-        jtrace_session.query(WorkItem).get(1), jtrace_session
+        jtrace_session.get(WorkItem, 1), jtrace_session
     )).all()
     assert {item.id for item in related} == {2, 3, 4}
 
     related = jtrace_session.scalars(workitems.select_workitems_related_to_workitem(
-        jtrace_session.query(WorkItem).get(2), jtrace_session
+        jtrace_session.get(WorkItem, 2), jtrace_session
     )).all()
     assert {item.id for item in related} == {1, 3, 4}
 
@@ -77,7 +77,7 @@ def test_get_extended_workitem_superuser(jtrace_session):
     jtrace_session.commit()
 
     record = workitems.extend_workitem(
-        jtrace_session.query(WorkItem).get(1), jtrace_session
+        jtrace_session.get(WorkItem, 1), jtrace_session
     )
     assert record
     assert record.id == 1
@@ -95,19 +95,19 @@ def test_get_extended_workitem_superuser(jtrace_session):
 
 def test_get_workitem_collection(jtrace_session):
     collection = jtrace_session.scalars(workitems.select_workitem_collection(
-        jtrace_session.query(WorkItem).get(1), jtrace_session
+        jtrace_session.get(WorkItem, 1), jtrace_session
     )).all()
     assert {item.id for item in collection} == set()
 
     collection = jtrace_session.scalars(workitems.select_workitem_collection(
-        jtrace_session.query(WorkItem).get(2), jtrace_session
+        jtrace_session.get(WorkItem, 2), jtrace_session
     )).all()
     assert {item.id for item in collection} == {3, 4}
 
 
 def test_get_workitems_related_to_message(jtrace_session, errorsdb_session):
     related = jtrace_session.scalars(workitems.select_workitems_related_to_message(
-        errorsdb_session.query(Message).get(3), jtrace_session
+        errorsdb_session.get(Message, 3), jtrace_session
     )).all()
     assert {item.id for item in related} == {3}
 

--- a/tests/test_routers/test_admin.py
+++ b/tests/test_routers/test_admin.py
@@ -1,7 +1,4 @@
 from ukrdc_fastapi.config import configuration
-from ukrdc_fastapi.query.admin import AdminCountsSchema
-from ukrdc_fastapi.routers.api.admin.datahealth import WorkItemGroup
-from ukrdc_fastapi.schemas.common import HistoryPoint
 
 
 async def test_full_workitem_history(client_superuser):

--- a/tests/test_routers/test_masterrecords.py
+++ b/tests/test_routers/test_masterrecords.py
@@ -1,7 +1,6 @@
 from ukrdc_fastapi.config import configuration
 from ukrdc_fastapi.schemas.empi import WorkItemSchema
 from ukrdc_fastapi.schemas.patientrecord import PatientRecordSummarySchema
-from ukrdc_fastapi.utils.mirth import MirthMessageResponseSchema
 
 
 async def test_masterrecord_detail(client_authenticated):

--- a/tests/test_routers/test_patientrecords/test_delete.py
+++ b/tests/test_routers/test_patientrecords/test_delete.py
@@ -14,18 +14,18 @@ async def test_delete_summary(client_superuser, ukrdc3_session, jtrace_session):
     summary = DeletePIDResponseSchema(**response.json())
 
     # Assert all expected records exist
-    assert ukrdc3_session.query(PatientRecord).get("PYTEST03:PV:00000000A")
+    assert ukrdc3_session.get(PatientRecord, "PYTEST03:PV:00000000A")
 
     for person in summary.empi.persons:
-        assert jtrace_session.query(Person).get(person.id)
+        assert jtrace_session.get(Person, person.id)
     for master_record in summary.empi.master_records:
-        assert jtrace_session.query(MasterRecord).get(master_record.id)
+        assert jtrace_session.get(MasterRecord, master_record.id)
     for pidxref in summary.empi.pidxrefs:
-        assert jtrace_session.query(PidXRef).get(pidxref.id)
+        assert jtrace_session.get(PidXRef, pidxref.id)
     for work_item in summary.empi.work_items:
-        assert jtrace_session.query(WorkItem).get(work_item.id)
+        assert jtrace_session.get(WorkItem, work_item.id)
     for link_record in summary.empi.link_records:
-        assert jtrace_session.query(LinkRecord).get(link_record.id)
+        assert jtrace_session.get(LinkRecord, link_record.id)
 
 
 async def test_delete(client_superuser, ukrdc3_session, jtrace_session):
@@ -37,18 +37,18 @@ async def test_delete(client_superuser, ukrdc3_session, jtrace_session):
     summary = DeletePIDResponseSchema(**response.json())
 
     # Assert all expected records exist
-    assert ukrdc3_session.query(PatientRecord).get("PYTEST03:PV:00000000A")
+    assert ukrdc3_session.get(PatientRecord, "PYTEST03:PV:00000000A")
 
     for person in summary.empi.persons:
-        assert jtrace_session.query(Person).get(person.id)
+        assert jtrace_session.get(Person, person.id)
     for master_record in summary.empi.master_records:
-        assert jtrace_session.query(MasterRecord).get(master_record.id)
+        assert jtrace_session.get(MasterRecord, master_record.id)
     for pidxref in summary.empi.pidxrefs:
-        assert jtrace_session.query(PidXRef).get(pidxref.id)
+        assert jtrace_session.get(PidXRef, pidxref.id)
     for work_item in summary.empi.work_items:
-        assert jtrace_session.query(WorkItem).get(work_item.id)
+        assert jtrace_session.get(WorkItem, work_item.id)
     for link_record in summary.empi.link_records:
-        assert jtrace_session.query(LinkRecord).get(link_record.id)
+        assert jtrace_session.get(LinkRecord, link_record.id)
 
     deleted_response = await client_superuser.post(
         f"{configuration.base_url}/patientrecords/PYTEST03:PV:00000000A/delete",
@@ -62,17 +62,17 @@ async def test_delete(client_superuser, ukrdc3_session, jtrace_session):
     assert deleted.hash == summary.hash
 
     # Assert all expected records have been deleted
-    assert not ukrdc3_session.query(PatientRecord).get("PYTEST03:PV:00000000A")
+    assert not ukrdc3_session.get(PatientRecord, "PYTEST03:PV:00000000A")
     for person in summary.empi.persons:
-        assert not jtrace_session.query(Person).get(person.id)
+        assert not jtrace_session.get(Person, person.id)
     for master_record in summary.empi.master_records:
-        assert not jtrace_session.query(MasterRecord).get(master_record.id)
+        assert not jtrace_session.get(MasterRecord, master_record.id)
     for pidxref in summary.empi.pidxrefs:
-        assert not jtrace_session.query(PidXRef).get(pidxref.id)
+        assert not jtrace_session.get(PidXRef, pidxref.id)
     for work_item in summary.empi.work_items:
-        assert not jtrace_session.query(WorkItem).get(work_item.id)
+        assert not jtrace_session.get(WorkItem, work_item.id)
     for link_record in summary.empi.link_records:
-        assert not jtrace_session.query(LinkRecord).get(link_record.id)
+        assert not jtrace_session.get(LinkRecord, link_record.id)
 
 
 async def test_delete_badhash(client_superuser, ukrdc3_session):
@@ -83,7 +83,7 @@ async def test_delete_badhash(client_superuser, ukrdc3_session):
     assert response.status_code == 400
 
     # Assert expected record still exists
-    assert ukrdc3_session.query(PatientRecord).get("PYTEST03:PV:00000000A")
+    assert ukrdc3_session.get(PatientRecord, "PYTEST03:PV:00000000A")
 
 
 async def test_delete_denied(client_authenticated):

--- a/tests/test_routers/test_patientrecords/test_delete.py
+++ b/tests/test_routers/test_patientrecords/test_delete.py
@@ -16,6 +16,8 @@ async def test_delete_summary(client_superuser, ukrdc3_session, jtrace_session):
     # Assert all expected records exist
     assert ukrdc3_session.get(PatientRecord, "PYTEST03:PV:00000000A")
 
+    assert summary.empi
+
     for person in summary.empi.persons:
         assert jtrace_session.get(Person, person.id)
     for master_record in summary.empi.master_records:
@@ -39,6 +41,7 @@ async def test_delete(client_superuser, ukrdc3_session, jtrace_session):
     # Assert all expected records exist
     assert ukrdc3_session.get(PatientRecord, "PYTEST03:PV:00000000A")
 
+    assert summary.empi
     for person in summary.empi.persons:
         assert jtrace_session.get(Person, person.id)
     for master_record in summary.empi.master_records:
@@ -58,7 +61,7 @@ async def test_delete(client_superuser, ukrdc3_session, jtrace_session):
 
     deleted = DeletePIDResponseSchema(**deleted_response.json())
 
-    assert deleted.committed == True
+    assert deleted.committed is True
     assert deleted.hash == summary.hash
 
     # Assert all expected records have been deleted

--- a/tests/test_routers/test_patientrecords/test_dialysissessions.py
+++ b/tests/test_routers/test_patientrecords/test_dialysissessions.py
@@ -1,4 +1,5 @@
 from ukrdc_fastapi.config import configuration
+from ukrdc_fastapi.schemas.patientrecord.patientrecord import DialysisSessionSchema
 
 
 async def test_record_dialysis_sessions(client_superuser):
@@ -7,6 +8,8 @@ async def test_record_dialysis_sessions(client_superuser):
     )
     assert response.status_code == 200
 
+    assert len(response.json()) > 0
+    assert([DialysisSessionSchema(**x) for x in response.json().get("items")])
 
 async def test_record_dialysis_sessions_denied(client_authenticated):
     response = await client_authenticated.get(

--- a/tests/test_routers/test_patientrecords/test_dialysissessions.py
+++ b/tests/test_routers/test_patientrecords/test_dialysissessions.py
@@ -9,7 +9,8 @@ async def test_record_dialysis_sessions(client_superuser):
     assert response.status_code == 200
 
     assert len(response.json()) > 0
-    assert([DialysisSessionSchema(**x) for x in response.json().get("items")])
+    assert [DialysisSessionSchema(**x) for x in response.json().get("items")]
+
 
 async def test_record_dialysis_sessions_denied(client_authenticated):
     response = await client_authenticated.get(

--- a/tests/test_routers/test_patientrecords/test_export.py
+++ b/tests/test_routers/test_patientrecords/test_export.py
@@ -6,7 +6,6 @@ from ukrdc_sqla.ukrdc import ProgramMembership
 from tests.utils import days_ago
 from ukrdc_fastapi.config import configuration
 from ukrdc_fastapi.exceptions import NoActiveMembershipError
-from ukrdc_fastapi.utils.tasks import TrackableTaskSchema
 
 
 def _last_sent_mirth_message(httpx_mock) -> str:
@@ -30,6 +29,7 @@ async def test_record_export_data(client_authenticated):
     assert response.json().get("status") == "success"
     assert response.json().get("numberOfMessages") == 1
 
+
 @pytest.mark.asyncio
 async def test_record_export_tests(client_authenticated, httpx_mock):
     response = await client_authenticated.post(
@@ -40,6 +40,7 @@ async def test_record_export_tests(client_authenticated, httpx_mock):
     assert response.status_code == 200
     assert response.json().get("status") == "success"
     assert response.json().get("numberOfMessages") == 1
+
 
 @pytest.mark.asyncio
 async def test_record_export_docs(client_authenticated, httpx_mock):
@@ -52,6 +53,7 @@ async def test_record_export_docs(client_authenticated, httpx_mock):
     assert response.json().get("status") == "success"
     assert response.json().get("numberOfMessages") == 1
 
+
 @pytest.mark.asyncio
 async def test_record_export_radar(client_authenticated, httpx_mock):
     response = await client_authenticated.post(
@@ -62,6 +64,7 @@ async def test_record_export_radar(client_authenticated, httpx_mock):
     assert response.status_code == 200
     assert response.json().get("status") == "success"
     assert response.json().get("numberOfMessages") == 1
+
 
 @pytest.mark.asyncio
 async def test_record_export_pkb(client_authenticated, ukrdc3_session):

--- a/tests/test_routers/test_patientrecords/test_laborders.py
+++ b/tests/test_routers/test_patientrecords/test_laborders.py
@@ -59,8 +59,8 @@ async def test_laborder_delete(client_authenticated, ukrdc3_session):
     ukrdc3_session.commit()
 
     # Make sure the laborder was created
-    assert ukrdc3_session.query(LabOrder).get("LABORDER_TEMP")
-    assert ukrdc3_session.query(ResultItem).get("RESULTITEM_TEMP")
+    assert ukrdc3_session.get(LabOrder, "LABORDER_TEMP")
+    assert ukrdc3_session.get(ResultItem, "RESULTITEM_TEMP")
     response = await client_authenticated.get(
         f"{configuration.base_url}/patientrecords/PYTEST01:PV:00000000A/laborders/LABORDER_TEMP"
     )
@@ -77,8 +77,8 @@ async def test_laborder_delete(client_authenticated, ukrdc3_session):
         f"{configuration.base_url}/patientrecords/PYTEST01:PV:00000000A/laborders/LABORDER_TEMP"
     )
     assert response.status_code == 404
-    assert not ukrdc3_session.query(LabOrder).get("LABORDER_TEMP")
-    assert not ukrdc3_session.query(ResultItem).get("RESULTITEM_TEMP")
+    assert not ukrdc3_session.get(LabOrder, "LABORDER_TEMP")
+    assert not ukrdc3_session.get(ResultItem, "RESULTITEM_TEMP")
 
 
 async def test_laborder_delete_denied(client_authenticated):

--- a/tests/test_routers/test_patientrecords/test_laborders.py
+++ b/tests/test_routers/test_patientrecords/test_laborders.py
@@ -2,7 +2,7 @@ from ukrdc_sqla.ukrdc import LabOrder, ResultItem
 
 from tests.utils import days_ago
 from ukrdc_fastapi.config import configuration
-from ukrdc_fastapi.schemas.patientrecord.laborder import LabOrderSchema, LabOrderShortSchema
+from ukrdc_fastapi.schemas.patientrecord.laborder import LabOrderShortSchema
 
 
 async def test_record_laborders(client_authenticated):
@@ -13,7 +13,8 @@ async def test_record_laborders(client_authenticated):
 
     items = response.json().get("items", [])
     assert len(items) > 0
-    assert([LabOrderShortSchema(**x) for x in items])
+    assert [LabOrderShortSchema(**x) for x in items]
+
 
 async def test_record_laborders_denied(client_authenticated):
     response = await client_authenticated.get(

--- a/tests/test_routers/test_patientrecords/test_laborders.py
+++ b/tests/test_routers/test_patientrecords/test_laborders.py
@@ -2,7 +2,7 @@ from ukrdc_sqla.ukrdc import LabOrder, ResultItem
 
 from tests.utils import days_ago
 from ukrdc_fastapi.config import configuration
-from ukrdc_fastapi.schemas.patientrecord.laborder import LabOrderSchema
+from ukrdc_fastapi.schemas.patientrecord.laborder import LabOrderSchema, LabOrderShortSchema
 
 
 async def test_record_laborders(client_authenticated):
@@ -11,6 +11,9 @@ async def test_record_laborders(client_authenticated):
     )
     assert response.status_code == 200
 
+    items = response.json().get("items", [])
+    assert len(items) > 0
+    assert([LabOrderShortSchema(**x) for x in items])
 
 async def test_record_laborders_denied(client_authenticated):
     response = await client_authenticated.get(

--- a/tests/test_routers/test_patientrecords/test_medications.py
+++ b/tests/test_routers/test_patientrecords/test_medications.py
@@ -1,4 +1,5 @@
 from ukrdc_fastapi.config import configuration
+from ukrdc_fastapi.schemas.patientrecord.medication import MedicationSchema
 
 
 async def test_record_medications(client_superuser):
@@ -6,6 +7,10 @@ async def test_record_medications(client_superuser):
         f"{configuration.base_url}/patientrecords/PYTEST01:PV:00000000A/medications"
     )
     assert response.status_code == 200
+    
+    # Check for validation errors
+    assert len(response.json()) > 0
+    assert([MedicationSchema(**x) for x in response.json()])
 
 
 async def test_record_medications_denied(client_authenticated):

--- a/tests/test_routers/test_patientrecords/test_medications.py
+++ b/tests/test_routers/test_patientrecords/test_medications.py
@@ -7,10 +7,10 @@ async def test_record_medications(client_superuser):
         f"{configuration.base_url}/patientrecords/PYTEST01:PV:00000000A/medications"
     )
     assert response.status_code == 200
-    
+
     # Check for validation errors
     assert len(response.json()) > 0
-    assert([MedicationSchema(**x) for x in response.json()])
+    assert [MedicationSchema(**x) for x in response.json()]
 
 
 async def test_record_medications_denied(client_authenticated):

--- a/tests/test_routers/test_patientrecords/test_observations.py
+++ b/tests/test_routers/test_patientrecords/test_observations.py
@@ -8,9 +8,19 @@ async def test_record_observations(client_superuser):
     )
     assert response.status_code == 200
 
+    items = response.json().get("items", [])
+    assert len(items) > 0
+    assert([ObservationSchema(**x) for x in items])
 
 async def test_record_observations_denied(client_authenticated):
     response = await client_authenticated.get(
         f"{configuration.base_url}/patientrecords/PYTEST03:PV:00000000A/observations"
     )
     assert response.status_code == 403
+
+async def test_record_observation_codes(client_superuser):
+    response = await client_superuser.get(
+        f"{configuration.base_url}/patientrecords/PYTEST01:PV:00000000A/observation_codes"
+    )
+    assert response.status_code == 200
+    assert set(response.json()) == {'bpdia', 'OBSERVATION_CODE', 'bpsys'}

--- a/tests/test_routers/test_patientrecords/test_observations.py
+++ b/tests/test_routers/test_patientrecords/test_observations.py
@@ -10,7 +10,8 @@ async def test_record_observations(client_superuser):
 
     items = response.json().get("items", [])
     assert len(items) > 0
-    assert([ObservationSchema(**x) for x in items])
+    assert [ObservationSchema(**x) for x in items]
+
 
 async def test_record_observations_denied(client_authenticated):
     response = await client_authenticated.get(
@@ -18,9 +19,10 @@ async def test_record_observations_denied(client_authenticated):
     )
     assert response.status_code == 403
 
+
 async def test_record_observation_codes(client_superuser):
     response = await client_superuser.get(
         f"{configuration.base_url}/patientrecords/PYTEST01:PV:00000000A/observation_codes"
     )
     assert response.status_code == 200
-    assert set(response.json()) == {'bpdia', 'OBSERVATION_CODE', 'bpsys'}
+    assert set(response.json()) == {"bpdia", "OBSERVATION_CODE", "bpsys"}

--- a/tests/test_routers/test_patientrecords/test_resultitems.py
+++ b/tests/test_routers/test_patientrecords/test_resultitems.py
@@ -8,6 +8,9 @@ async def test_record_resultitems(client_superuser):
     )
     assert response.status_code == 200
 
+    items = response.json().get("items", [])
+    assert len(items) > 0
+    assert([ResultItemSchema(**x) for x in items])
 
 async def test_resultitems_list_filtered_serviceId(client_superuser):
     # Filter by NI
@@ -62,3 +65,12 @@ async def test_resultitem_delete_denied(client_authenticated):
         f"{configuration.base_url}/patientrecords/PYTEST03:PV:00000000A/results/RESULTITEM1"
     )
     assert response.status_code == 403
+
+
+async def test_record_resultitem_services(client_superuser):
+    response = await client_superuser.get(
+        f"{configuration.base_url}/patientrecords/PYTEST01:PV:00000000A/result_services"
+    )
+    assert response.status_code == 200
+    item_ids = {item.get("id") for item in response.json()}
+    assert item_ids == {"SERVICE_ID_1", "SERVICE_ID_2"}

--- a/tests/test_routers/test_patientrecords/test_resultitems.py
+++ b/tests/test_routers/test_patientrecords/test_resultitems.py
@@ -10,7 +10,8 @@ async def test_record_resultitems(client_superuser):
 
     items = response.json().get("items", [])
     assert len(items) > 0
-    assert([ResultItemSchema(**x) for x in items])
+    assert [ResultItemSchema(**x) for x in items]
+
 
 async def test_resultitems_list_filtered_serviceId(client_superuser):
     # Filter by NI

--- a/tests/test_routers/test_patientrecords/test_surveys.py
+++ b/tests/test_routers/test_patientrecords/test_surveys.py
@@ -1,4 +1,5 @@
 from ukrdc_fastapi.config import configuration
+from ukrdc_fastapi.schemas.patientrecord.survey import SurveySchema
 
 
 async def test_record_surveys(client_superuser):
@@ -7,6 +8,8 @@ async def test_record_surveys(client_superuser):
     )
     assert response.status_code == 200
 
+    assert len(response.json()) > 0
+    assert([SurveySchema(**x) for x in response.json()])
 
 async def test_record_surveys_denied(client_authenticated):
     response = await client_authenticated.get(

--- a/tests/test_routers/test_patientrecords/test_surveys.py
+++ b/tests/test_routers/test_patientrecords/test_surveys.py
@@ -9,7 +9,8 @@ async def test_record_surveys(client_superuser):
     assert response.status_code == 200
 
     assert len(response.json()) > 0
-    assert([SurveySchema(**x) for x in response.json()])
+    assert [SurveySchema(**x) for x in response.json()]
+
 
 async def test_record_surveys_denied(client_authenticated):
     response = await client_authenticated.get(

--- a/tests/test_routers/test_patientrecords/test_transplants.py
+++ b/tests/test_routers/test_patientrecords/test_transplants.py
@@ -1,4 +1,5 @@
 from ukrdc_fastapi.config import configuration
+from ukrdc_fastapi.schemas.patientrecord.procedure import TransplantSchema
 
 
 async def test_record_transplants(client_superuser):

--- a/tests/test_routers/test_patientrecords/test_transplants.py
+++ b/tests/test_routers/test_patientrecords/test_transplants.py
@@ -1,5 +1,4 @@
 from ukrdc_fastapi.config import configuration
-from ukrdc_fastapi.schemas.patientrecord.procedure import TransplantSchema
 
 
 async def test_record_transplants(client_superuser):

--- a/tests/test_routers/test_patientrecords/test_treatments.py
+++ b/tests/test_routers/test_patientrecords/test_treatments.py
@@ -1,4 +1,3 @@
-from tests.utils import days_ago
 from ukrdc_fastapi.config import configuration
 from ukrdc_fastapi.schemas.patientrecord.treatments import TreatmentSchema
 
@@ -10,7 +9,7 @@ async def test_record_treatments(client_superuser):
     assert response.status_code == 200
 
     assert len(response.json()) > 0
-    assert([TreatmentSchema(**x) for x in response.json()])
+    assert [TreatmentSchema(**x) for x in response.json()]
 
 
 async def test_record_treatments_denied(client_authenticated):

--- a/tests/test_routers/test_patientrecords/test_treatments.py
+++ b/tests/test_routers/test_patientrecords/test_treatments.py
@@ -1,5 +1,6 @@
 from tests.utils import days_ago
 from ukrdc_fastapi.config import configuration
+from ukrdc_fastapi.schemas.patientrecord.treatments import TreatmentSchema
 
 
 async def test_record_treatments(client_superuser):
@@ -7,6 +8,9 @@ async def test_record_treatments(client_superuser):
         f"{configuration.base_url}/patientrecords/PYTEST01:PV:00000000A/treatments"
     )
     assert response.status_code == 200
+
+    assert len(response.json()) > 0
+    assert([TreatmentSchema(**x) for x in response.json()])
 
 
 async def test_record_treatments_denied(client_authenticated):

--- a/tests/test_routers/test_search/test_search_patientrecords.py
+++ b/tests/test_routers/test_search/test_search_patientrecords.py
@@ -1,6 +1,6 @@
 from urllib.parse import quote
 from ukrdc_fastapi.config import configuration
-from .utils import commit_extra_patients, TEST_NUMBERS, BUMPER
+from .utils import commit_extra_patients, TEST_NUMBERS
 
 # NB: We only need the jtrace session here because our test utility function to create new patients uses it.
 # Long-term (post-JTRACE) it will not be required.
@@ -79,8 +79,11 @@ async def test_search_facility_superuser(
         response = await client_superuser.get(url)
         assert response.status_code == 200
 
-        returned_facilities = {item["sendingfacility"] for item in response.json()["items"]}
+        returned_facilities = {
+            item["sendingfacility"] for item in response.json()["items"]
+        }
         assert returned_facilities == {facility}
+
 
 async def test_search_extract_superuser(
     ukrdc3_session, jtrace_session, client_superuser
@@ -94,8 +97,11 @@ async def test_search_extract_superuser(
         response = await client_superuser.get(url)
         assert response.status_code == 200
 
-        returned_extracts = {item["sendingextract"] for item in response.json()["items"]}
+        returned_extracts = {
+            item["sendingextract"] for item in response.json()["items"]
+        }
         assert returned_extracts == {extract}
+
 
 async def test_search_name(ukrdc3_session, jtrace_session, client_superuser):
     # Add extra test items
@@ -176,7 +182,9 @@ async def test_search_implicit_facility(
         response = await client_superuser.get(url)
         assert response.status_code == 200
 
-        returned_facilities = {item["sendingfacility"] for item in response.json()["items"]}
+        returned_facilities = {
+            item["sendingfacility"] for item in response.json()["items"]
+        }
         assert returned_facilities == {facility}
 
 

--- a/tests/test_routers/test_search/utils.py
+++ b/tests/test_routers/test_search/utils.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from ...utils import create_basic_facility, create_basic_patient
+from ...utils import create_basic_patient
 
 TEST_NUMBERS = [
     "9434765870",

--- a/tests/test_tasks/test_tasks_utils.py
+++ b/tests/test_tasks/test_tasks_utils.py
@@ -123,10 +123,14 @@ async def test_repeat_log_error(caplog: LogCaptureFixture) -> None:
 
 
 @pytest.mark.asyncio
-async def test_repeat_raise_error(caplog: LogCaptureFixture, capsys: CaptureFixture[str]) -> None:
+async def test_repeat_raise_error(
+    caplog: LogCaptureFixture, capsys: CaptureFixture[str]
+) -> None:
     logger = logging.getLogger(__name__)
 
-    @repeat_every(seconds=0.07, max_repetitions=None, raise_exceptions=True, logger=logger)
+    @repeat_every(
+        seconds=0.07, max_repetitions=None, raise_exceptions=True, logger=logger
+    )
     def raise_exc() -> NoReturn:
         raise ValueError("repeat")
 

--- a/tests/test_utils/test_cache.py
+++ b/tests/test_utils/test_cache.py
@@ -5,7 +5,7 @@ from ukrdc_fastapi.utils.cache import (
     BasicCache,
     CacheNotSetException,
     DynamicCacheKey,
-    TestCachePrefix,
+    PytestCachePrefix,
 )
 
 
@@ -23,7 +23,7 @@ class PydanticModel(BaseModel):
 
 
 def test_basic_cache_empty(redis_session):
-    cache = BasicCache(redis_session, DynamicCacheKey(TestCachePrefix.PYTEST, "1"))
+    cache = BasicCache(redis_session, DynamicCacheKey(PytestCachePrefix.PYTEST, "1"))
     assert cache.exists is False
 
     with pytest.raises(CacheNotSetException):
@@ -31,7 +31,7 @@ def test_basic_cache_empty(redis_session):
 
 
 def test_basic_cache_set_primitive(redis_session):
-    cache = BasicCache(redis_session, DynamicCacheKey(TestCachePrefix.PYTEST, "2"))
+    cache = BasicCache(redis_session, DynamicCacheKey(PytestCachePrefix.PYTEST, "2"))
     assert cache.exists is False
 
     cache.set("foo")
@@ -42,7 +42,7 @@ def test_basic_cache_set_primitive(redis_session):
 
 
 def test_basic_cache_set_dict(redis_session):
-    cache = BasicCache(redis_session, DynamicCacheKey(TestCachePrefix.PYTEST, "3"))
+    cache = BasicCache(redis_session, DynamicCacheKey(PytestCachePrefix.PYTEST, "3"))
     assert cache.exists is False
 
     cache.set(
@@ -67,7 +67,7 @@ def test_basic_cache_set_dict(redis_session):
 
 
 def test_basic_cache_set_pydantic(redis_session):
-    cache = BasicCache(redis_session, DynamicCacheKey(TestCachePrefix.PYTEST, "4"))
+    cache = BasicCache(redis_session, DynamicCacheKey(PytestCachePrefix.PYTEST, "4"))
     assert cache.exists is False
 
     cache.set(
@@ -95,7 +95,7 @@ def test_basic_cache_set_pydantic(redis_session):
 
 
 def test_basic_cache_restore(redis_session):
-    cache_key = DynamicCacheKey(TestCachePrefix.PYTEST, "5")
+    cache_key = DynamicCacheKey(PytestCachePrefix.PYTEST, "5")
 
     cache_1 = BasicCache(redis_session, cache_key)
     assert cache_1.exists is False

--- a/tests/test_utils/test_mirth/test_messages/test_messages.py
+++ b/tests/test_utils/test_mirth/test_messages/test_messages.py
@@ -1,5 +1,4 @@
 from ukrdc_fastapi.utils.mirth.messages import (
-    build_close_workitem_message,
     build_export_all_message,
     build_export_docs_message,
     build_export_radar_message,

--- a/tests/test_utils/test_mirth/test_messages/test_pkb.py
+++ b/tests/test_utils/test_mirth/test_messages/test_pkb.py
@@ -36,7 +36,7 @@ def test_build_pkb_membership_message():
 def test_build_pkb_sync_message(ukrdc3_session):
     PID_1 = "PYTEST01:PV:00000000A"
     _create_membership(PID_1, ukrdc3_session)
-    record = ukrdc3_session.query(PatientRecord).get(PID_1)
+    record = ukrdc3_session.get(PatientRecord, PID_1)
 
     messages = build_pkb_sync_messages(record, ukrdc3_session)
     assert messages == [
@@ -54,7 +54,7 @@ def test_build_pkb_sync_message(ukrdc3_session):
 
 def test_build_pkb_sync_message_no_membership(ukrdc3_session):
     PID_1 = "PYTEST01:PV:00000000A"
-    record = ukrdc3_session.query(PatientRecord).get(PID_1)
+    record = ukrdc3_session.get(PatientRecord, PID_1)
 
     with pytest.raises(NoActiveMembershipError):
         build_pkb_sync_messages(record, ukrdc3_session)
@@ -63,7 +63,7 @@ def test_build_pkb_sync_message_no_membership(ukrdc3_session):
 def test_build_pkb_sync_message_missing_facility(ukrdc3_session):
     PID_1 = "PYTEST01:PV:00000000A"
     _create_membership(PID_1, ukrdc3_session)
-    record = ukrdc3_session.query(PatientRecord).get(PID_1)
+    record = ukrdc3_session.get(PatientRecord, PID_1)
 
     record.sendingfacility = "MISSING"
     ukrdc3_session.commit()
@@ -75,9 +75,9 @@ def test_build_pkb_sync_message_missing_facility(ukrdc3_session):
 def test_build_pkb_sync_disabled_facility(ukrdc3_session):
     PID_1 = "PYTEST01:PV:00000000A"
     _create_membership(PID_1, ukrdc3_session)
-    record = ukrdc3_session.query(PatientRecord).get(PID_1)
+    record = ukrdc3_session.get(PatientRecord, PID_1)
 
-    facility = ukrdc3_session.query(Facility).get(record.sendingfacility)
+    facility = ukrdc3_session.get(Facility, record.sendingfacility)
     facility.pkb_out = False
     ukrdc3_session.commit()
 
@@ -89,7 +89,7 @@ def test_build_pkb_sync_disabled_facility(ukrdc3_session):
 def test_build_pkb_sync_disabled_extract(ukrdc3_session, extract):
     PID_1 = "PYTEST01:PV:00000000A"
     _create_membership(PID_1, ukrdc3_session)
-    record = ukrdc3_session.query(PatientRecord).get(PID_1)
+    record = ukrdc3_session.get(PatientRecord, PID_1)
 
     record.sendingextract = extract
     ukrdc3_session.commit()
@@ -101,9 +101,9 @@ def test_build_pkb_sync_disabled_extract(ukrdc3_session, extract):
 def test_build_pkb_sync_message_facility_exclusions(ukrdc3_session):
     PID_1 = "PYTEST01:PV:00000000A"
     _create_membership(PID_1, ukrdc3_session)
-    record = ukrdc3_session.query(PatientRecord).get(PID_1)
+    record = ukrdc3_session.get(PatientRecord, PID_1)
 
-    facility = ukrdc3_session.query(Facility).get(record.sendingfacility)
+    facility = ukrdc3_session.get(Facility, record.sendingfacility)
     facility.pkb_msg_exclusions = ["MDM_T02_DOC"]
     ukrdc3_session.commit()
 

--- a/tests/test_utils/test_mirth/test_messages/test_rda.py
+++ b/tests/test_utils/test_mirth/test_messages/test_rda.py
@@ -8,7 +8,7 @@ from ukrdc_fastapi.utils.mirth.messages.rda import build_demographic_update_mess
 
 def test_build_demographic_update_message(ukrdc3_session):
     PID_1 = "PYTEST01:PV:00000000A"
-    record = ukrdc3_session.query(PatientRecord).get(PID_1)
+    record = ukrdc3_session.get(PatientRecord, PID_1)
 
     message = build_demographic_update_message(
         record,
@@ -29,7 +29,7 @@ def test_build_demographic_update_message(ukrdc3_session):
 
 def test_build_demographic_update_message_no_changes(ukrdc3_session):
     PID_1 = "PYTEST01:PV:00000000A"
-    record = ukrdc3_session.query(PatientRecord).get(PID_1)
+    record = ukrdc3_session.get(PatientRecord, PID_1)
 
     message = build_demographic_update_message(
         record, name=None, birth_time=None, gender=None, address=None
@@ -46,7 +46,7 @@ def test_build_demographic_update_message_no_changes(ukrdc3_session):
 
 def test_build_demographic_update_message_full_address(ukrdc3_session):
     PID_1 = "PYTEST01:PV:00000000A"
-    record = ukrdc3_session.query(PatientRecord).get(PID_1)
+    record = ukrdc3_session.get(PatientRecord, PID_1)
 
     message = build_demographic_update_message(
         record,

--- a/tests/test_utils/test_utils.py
+++ b/tests/test_utils/test_utils.py
@@ -13,4 +13,3 @@ def test_build_db_uri_sqlite():
         utils.build_db_uri("sqlite", "host", 5432, "user", "pass", "dbname")
         == "sqlite:///dbname"
     )
-

--- a/tests/test_utils/test_utils.py
+++ b/tests/test_utils/test_utils.py
@@ -1,7 +1,3 @@
-import pytest
-from ukrdc_sqla.ukrdc import PatientRecord
-
-from tests.conftest import PID_1, PID_2, PID_3, UKRDCID_1, UKRDCID_2
 from ukrdc_fastapi import utils
 
 
@@ -18,46 +14,3 @@ def test_build_db_uri_sqlite():
         == "sqlite:///dbname"
     )
 
-
-def test_query_union_one(ukrdc3_session):
-    q1 = ukrdc3_session.query(PatientRecord).filter(PatientRecord.pid == PID_1)
-
-    u = utils.query_union([q1])
-    assert {record.pid for record in u} == {PID_1}
-
-
-def test_query_union_multiple(ukrdc3_session):
-    pids_to_test = {PID_1, PID_2, PID_3}
-    qs = [
-        ukrdc3_session.query(PatientRecord).filter(PatientRecord.pid == test_pid)
-        for test_pid in pids_to_test
-    ]
-
-    u = utils.query_union(qs)
-    assert {record.pid for record in u} == pids_to_test
-
-
-def test_query_union_multiple_overlapping(ukrdc3_session):
-    pids_to_test = {PID_1, PID_2, PID_3}
-    ukrdcids_to_test = {UKRDCID_1, UKRDCID_2}
-    qs = [
-        ukrdc3_session.query(PatientRecord).filter(PatientRecord.pid == test_pid)
-        for test_pid in pids_to_test
-    ]
-
-    qs.extend(
-        [
-            ukrdc3_session.query(PatientRecord).filter(
-                PatientRecord.ukrdcid == test_ukrdcid
-            )
-            for test_ukrdcid in ukrdcids_to_test
-        ]
-    )
-
-    u = utils.query_union(qs)
-    assert {record.pid for record in u} == pids_to_test
-
-
-def test_query_union_none():
-    with pytest.raises(ValueError):
-        utils.query_union([])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -49,7 +49,13 @@ def create_basic_patient(
             ethnic_group_code="G",
             ethnic_group_description="ETHNICITY_GROUP",
             names=[
-                Name(id=id_, pid=pid, family=family_name, given=given_name, nameuse="L")
+                Name(
+                    id=str(id_),
+                    pid=pid,
+                    family=family_name,
+                    given=given_name,
+                    nameuse="L",
+                )
             ],
             addresses=[
                 Address(
@@ -64,7 +70,7 @@ def create_basic_patient(
             ],
             numbers=[
                 PatientNumber(
-                    id=id_,
+                    id=str(id_),
                     pid=pid,
                     patientid=nhs_number,
                     organization="NHS",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = format, mypy, lint, bandit, pytest
 
 [testenv]
 allowlist_externals = poetry
-commands =
+commands_pre =
     poetry install -v
 
 [testenv:format]

--- a/tox.ini
+++ b/tox.ini
@@ -9,15 +9,15 @@ commands_pre =
 
 [testenv:format]
 description = 'Check code style with ruff'
-commands = poetry run ruff format ./ukrdc_fastapi --check
+commands = poetry run ruff format . --check
 
 [testenv:lint]
 description = 'Lint code with ruff'
-commands = poetry run ruff ukrdc_fastapi/
+commands = poetry run ruff .
 
 [testenv:mypy]
 description = 'Type-check code with mypy'
-commands = poetry run mypy ukrdc_fastapi/ --check-untyped-defs
+commands = poetry run mypy . --check-untyped-defs
 
 [testenv:bandit]
 description = 'Security-audit code with bandit'

--- a/ukrdc_fastapi/dependencies/audit.py
+++ b/ukrdc_fastapi/dependencies/audit.py
@@ -2,9 +2,9 @@ from datetime import datetime
 from enum import Enum
 from typing import AsyncGenerator, Optional, Union
 
-from starlette.requests import ClientDisconnect
 from fastapi import Depends, Request, Security
 from sqlalchemy.orm.session import Session
+from starlette.requests import ClientDisconnect
 from ukrdc_sqla.empi import WorkItem
 
 from ukrdc_fastapi.dependencies import get_auditdb

--- a/ukrdc_fastapi/dependencies/audit.py
+++ b/ukrdc_fastapi/dependencies/audit.py
@@ -160,9 +160,9 @@ class Auditer:
         )
         audited_master_ids: set[int] = set()
         audited_person_ids: set[int] = set()
-        if workitem.master_record:
+        if workitem.master_record and workitem.master_record.id:
             audited_master_ids.add(workitem.master_record.id)
-        if workitem.person:
+        if workitem.person and workitem.person.id:
             audited_person_ids.add(workitem.person.id)
 
         if isinstance(workitem, WorkItemExtendedSchema):

--- a/ukrdc_fastapi/dependencies/sentry.py
+++ b/ukrdc_fastapi/dependencies/sentry.py
@@ -2,11 +2,11 @@ import logging
 
 import sentry_sdk
 from fastapi import FastAPI
-from sentry_sdk.integrations.starlette import StarletteIntegration
-from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
+from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.redis import RedisIntegration
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
+from sentry_sdk.integrations.starlette import StarletteIntegration
 
 from ukrdc_fastapi.config import configuration
 

--- a/ukrdc_fastapi/main.py
+++ b/ukrdc_fastapi/main.py
@@ -1,5 +1,5 @@
-from contextlib import asynccontextmanager
 import re
+from contextlib import asynccontextmanager
 
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware

--- a/ukrdc_fastapi/models/audit.py
+++ b/ukrdc_fastapi/models/audit.py
@@ -34,10 +34,12 @@ class AuditEvent(Base):
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     parent_id = Column(Integer, ForeignKey("audit_event.id"))
-    children = relationship("AuditEvent")
+    children: Mapped[list["AuditEvent"]] = relationship("AuditEvent")
 
     access_event_id = Column(Integer, ForeignKey("access_event.id"))
-    access_event = relationship("AccessEvent", back_populates="audit_events")
+    access_event: Mapped["AccessEvent"] = relationship(
+        "AccessEvent", back_populates="audit_events"
+    )
 
     resource = Column(String)  # Resource type (null if self)
     resource_id = Column(String)  # Resource ID if applicable

--- a/ukrdc_fastapi/permissions/messages.py
+++ b/ukrdc_fastapi/permissions/messages.py
@@ -1,16 +1,16 @@
-from sqlalchemy.orm.query import Query
+from sqlalchemy.sql.selectable import Select
 from ukrdc_sqla.errorsdb import Message
 
 from ukrdc_fastapi.dependencies.auth import Permissions, UKRDCUser
 from ukrdc_fastapi.exceptions import PermissionsError
 
 
-def apply_message_list_permissions(query: Query, user: UKRDCUser):
+def apply_message_list_permissions(stmt: Select, user: UKRDCUser):
     units = Permissions.unit_codes(user.permissions)
     if Permissions.UNIT_WILDCARD in units:
-        return query
+        return stmt
 
-    return query.filter(Message.facility.in_(units))
+    return stmt.where(Message.facility.in_(units))
 
 
 def assert_message_permissions(message: Message, user: UKRDCUser):

--- a/ukrdc_fastapi/permissions/patientrecords.py
+++ b/ukrdc_fastapi/permissions/patientrecords.py
@@ -1,6 +1,6 @@
-from sqlalchemy import select, or_, and_, exists
-from sqlalchemy.sql.selectable import Select
+from sqlalchemy import and_, exists, or_, select
 from sqlalchemy.orm.session import Session
+from sqlalchemy.sql.selectable import Select
 from ukrdc_sqla.ukrdc import PatientRecord
 
 from ukrdc_fastapi.dependencies.auth import Permissions, UKRDCUser

--- a/ukrdc_fastapi/permissions/patientrecords.py
+++ b/ukrdc_fastapi/permissions/patientrecords.py
@@ -12,7 +12,6 @@ def assert_patientrecord_permission(
     record: PatientRecord, ukrdc3: Session, user: UKRDCUser
 ):
     units = Permissions.unit_codes(user.permissions)
-    print(units)
 
     # If the user has full admin permissions, return success
     if Permissions.UNIT_WILDCARD in units:

--- a/ukrdc_fastapi/permissions/patientrecords.py
+++ b/ukrdc_fastapi/permissions/patientrecords.py
@@ -1,5 +1,5 @@
-from sqlalchemy import or_
-from sqlalchemy.orm import Query
+from sqlalchemy import select, or_, and_, exists
+from sqlalchemy.sql.selectable import Select
 from sqlalchemy.orm.session import Session
 from ukrdc_sqla.ukrdc import PatientRecord
 
@@ -12,6 +12,7 @@ def assert_patientrecord_permission(
     record: PatientRecord, ukrdc3: Session, user: UKRDCUser
 ):
     units = Permissions.unit_codes(user.permissions)
+    print(units)
 
     # If the user has full admin permissions, return success
     if Permissions.UNIT_WILDCARD in units:
@@ -24,12 +25,11 @@ def assert_patientrecord_permission(
     # Otherwise, we have a more complicated situation like a multi-facility record.
     # We lean on our ability to determine permissions of groups of records
     if record.ukrdcid:
-        related_related_records = ukrdc3.query(PatientRecord).filter(
-            PatientRecord.ukrdcid == record.ukrdcid
-        )
-        allowed_related_records = apply_patientrecord_list_permission(
-            related_related_records, user
-        )
+        stmt = select(PatientRecord).where(PatientRecord.ukrdcid == record.ukrdcid)
+        stmt = apply_patientrecord_list_permission(stmt, user)
+
+        # Execute the statement and fetch all rows
+        allowed_related_records = ukrdc3.scalars(stmt).all()
 
         # If the user has explicit permission to access another record with the same UKRDCID
         if record.pid in (record.pid for record in allowed_related_records):
@@ -38,23 +38,24 @@ def assert_patientrecord_permission(
     raise PermissionsError()
 
 
-def apply_patientrecord_list_permission(query: Query, user: UKRDCUser):
+def apply_patientrecord_list_permission(stmt: Select, user: UKRDCUser):
     units = Permissions.unit_codes(user.permissions)
     if Permissions.UNIT_WILDCARD in units:
-        return query
+        return stmt
 
     # Find which records the user has explicit facility-permission to access
-    query_explicit_permissions = query.filter(PatientRecord.sendingfacility.in_(units))
+    stmt_explicit_permissions = stmt.where(PatientRecord.sendingfacility.in_(units))
 
-    # If the user doesn't have permission to see any, return the currently-empty query
-    if query_explicit_permissions.count() < 1:
-        return query_explicit_permissions
+    # Create a subquery to check if there are any rows that match the first condition
+    subquery = select([1]).select_from(stmt_explicit_permissions.alias()).limit(1)
 
-    # Else, if the user has explicit facility-permission to see more than 1 matching record,
-    # include multi-facility records like membership and informational records
-    return query.filter(
+    # Add the second condition if there are any rows that match the first condition
+    return stmt.where(
         or_(
             PatientRecord.sendingfacility.in_(units),
-            PatientRecord.sendingfacility.in_(ABSTRACT_FACILITIES),
+            and_(
+                exists(subquery),
+                PatientRecord.sendingfacility.in_(ABSTRACT_FACILITIES),
+            ),
         )
     )

--- a/ukrdc_fastapi/permissions/persons.py
+++ b/ukrdc_fastapi/permissions/persons.py
@@ -1,4 +1,4 @@
-from sqlalchemy.orm.query import Query
+from sqlalchemy.sql.selectable import Select
 from ukrdc_sqla.empi import Person, PidXRef
 
 from ukrdc_fastapi.dependencies.auth import Permissions, UKRDCUser
@@ -6,12 +6,12 @@ from ukrdc_fastapi.exceptions import PermissionsError
 from ukrdc_fastapi.query.common import person_belongs_to_units
 
 
-def apply_persons_list_permission(query: Query, user: UKRDCUser):
+def apply_persons_list_permission(stmt: Select, user: UKRDCUser):
     units = Permissions.unit_codes(user.permissions)
     if Permissions.UNIT_WILDCARD in units:
-        return query
+        return stmt
 
-    return query.join(PidXRef).filter(PidXRef.sending_facility.in_(units))
+    return stmt.join(PidXRef).where(PidXRef.sending_facility.in_(units))
 
 
 def assert_person_permission(person: Person, user: UKRDCUser):

--- a/ukrdc_fastapi/permissions/workitems.py
+++ b/ukrdc_fastapi/permissions/workitems.py
@@ -1,4 +1,4 @@
-from sqlalchemy.orm.query import Query
+from sqlalchemy.sql.selectable import Select
 from ukrdc_sqla.empi import Person, PidXRef, WorkItem
 
 from ukrdc_fastapi.dependencies.auth import Permissions, UKRDCUser
@@ -6,12 +6,12 @@ from ukrdc_fastapi.exceptions import PermissionsError
 from ukrdc_fastapi.query.common import person_belongs_to_units
 
 
-def apply_workitem_list_permission(query: Query, user: UKRDCUser):
+def apply_workitem_list_permission(stmt: Select, user: UKRDCUser):
     units = Permissions.unit_codes(user.permissions)
     if Permissions.UNIT_WILDCARD in units:
-        return query
+        return stmt
 
-    return query.join(Person).join(PidXRef).filter(PidXRef.sending_facility.in_(units))
+    return stmt.join(Person).join(PidXRef).where(PidXRef.sending_facility.in_(units))
 
 
 def assert_workitem_permission(workitem: WorkItem, user: UKRDCUser):

--- a/ukrdc_fastapi/query/admin.py
+++ b/ukrdc_fastapi/query/admin.py
@@ -1,4 +1,5 @@
 from pydantic import Field
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 from ukrdc_sqla.empi import WorkItem
 from ukrdc_sqla.errorsdb import Latest, Message
@@ -21,6 +22,29 @@ class AdminCountsSchema(OrmModel):
     )
 
 
+def _open_workitems_count(jtrace: Session) -> int:
+    query = select(func.count()).select_from(WorkItem).filter(WorkItem.status == 1)
+    result = jtrace.execute(query)
+    return result.scalar()
+
+
+def _distinct_patients_count(ukrdc3: Session) -> int:
+    query = select(func.count(PatientRecord.ukrdcid.distinct()))
+    result = ukrdc3.execute(query)
+    return result.scalar()
+
+
+def _patients_receiving_errors_count(errorsdb: Session) -> int:
+    query = (
+        select(func.count())
+        .select_from(Latest)
+        .join(Message)
+        .filter(Message.msg_status == "ERROR")
+    )
+    result = errorsdb.execute(query)
+    return result.scalar()
+
+
 def get_admin_counts(
     ukrdc3: Session, jtrace: Session, errorsdb: Session
 ) -> AdminCountsSchema:
@@ -34,17 +58,8 @@ def get_admin_counts(
     Returns:
         AdminCountsSchema: Counts of various items
     """
-    open_workitems_count = jtrace.query(WorkItem).filter(WorkItem.status == 1).count()
-    distinct_patients_count = ukrdc3.query(PatientRecord.ukrdcid).distinct().count()
-    patients_receiving_errors_count = (
-        errorsdb.query(Latest)
-        .join(Message)
-        .filter(Message.msg_status == "ERROR")
-        .count()
-    )
-
     return AdminCountsSchema(
-        open_workitems=open_workitems_count,
-        distinct_patients=distinct_patients_count,
-        patients_receiving_errors=patients_receiving_errors_count,
+        open_workitems=_open_workitems_count(jtrace),
+        distinct_patients=_distinct_patients_count(ukrdc3),
+        patients_receiving_errors=_patients_receiving_errors_count(errorsdb),
     )

--- a/ukrdc_fastapi/query/admin.py
+++ b/ukrdc_fastapi/query/admin.py
@@ -23,7 +23,7 @@ class AdminCountsSchema(OrmModel):
 
 
 def _open_workitems_count(jtrace: Session) -> int:
-    query = select(func.count()).select_from(WorkItem).filter(WorkItem.status == 1)
+    query = select(func.count()).select_from(WorkItem).where(WorkItem.status == 1)
     result = jtrace.execute(query)
     return result.scalar()
 
@@ -39,7 +39,7 @@ def _patients_receiving_errors_count(errorsdb: Session) -> int:
         select(func.count())
         .select_from(Latest)
         .join(Message)
-        .filter(Message.msg_status == "ERROR")
+        .where(Message.msg_status == "ERROR")
     )
     result = errorsdb.execute(query)
     return result.scalar()

--- a/ukrdc_fastapi/query/admin.py
+++ b/ukrdc_fastapi/query/admin.py
@@ -1,4 +1,5 @@
 from typing import Any
+
 from pydantic import Field
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session

--- a/ukrdc_fastapi/query/codes.py
+++ b/ukrdc_fastapi/query/codes.py
@@ -1,8 +1,8 @@
 from typing import Optional
-from sqlalchemy import or_, select
-from sqlalchemy.sql.selectable import Select
 
+from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
+from sqlalchemy.sql.selectable import Select
 from ukrdc_sqla.ukrdc import Code, CodeExclusion, CodeMap
 
 from ukrdc_fastapi.exceptions import MissingCodeError

--- a/ukrdc_fastapi/query/codes.py
+++ b/ukrdc_fastapi/query/codes.py
@@ -60,13 +60,17 @@ def get_code(ukrdc3: Session, coding_standard: str, code: str) -> ExtendedCodeSc
 
     maps_to = ukrdc3.scalars(
         select_code_maps(
-            source_coding_standard=[code_obj.coding_standard],
+            source_coding_standard=[code_obj.coding_standard]
+            if code_obj.coding_standard
+            else [],
             source_code=code_obj.code,
         )
     ).all()
     mapped_by = ukrdc3.scalars(
         select_code_maps(
-            destination_coding_standard=[code_obj.coding_standard],
+            destination_coding_standard=[code_obj.coding_standard]
+            if code_obj.coding_standard
+            else [],
             destination_code=code_obj.code,
         )
     ).all()

--- a/ukrdc_fastapi/query/delete.py
+++ b/ukrdc_fastapi/query/delete.py
@@ -129,6 +129,9 @@ def summarise_delete_patientrecord(
     Returns:
         DeletePIDResponseSchema: Summary of database items to be deleted
     """
+    if not record_to_delete.pid:
+        raise ValueError("Target PatientRecord does not have a PID")
+
     empi_to_delete = _find_empi_items_to_delete(jtrace, record_to_delete.pid)
 
     return _create_delete_patientrecord_summary(record_to_delete, empi_to_delete)
@@ -154,6 +157,9 @@ def delete_patientrecord(
     Returns:
         DeletePIDResponseSchema:  Summary of database items deleted
     """
+    if not record_to_delete.pid:
+        raise ValueError("Target PatientRecord does not have a PID")
+
     empi_to_delete = _find_empi_items_to_delete(jtrace, record_to_delete.pid)
 
     summary = _create_delete_patientrecord_summary(

--- a/ukrdc_fastapi/query/delete.py
+++ b/ukrdc_fastapi/query/delete.py
@@ -130,7 +130,7 @@ def summarise_delete_patientrecord(
         DeletePIDResponseSchema: Summary of database items to be deleted
     """
     if not record_to_delete.pid:
-        raise ValueError("Target PatientRecord does not have a PID")
+        raise ValueError("Target PatientRecord does not have a PID")  # pragma: no cover
 
     empi_to_delete = _find_empi_items_to_delete(jtrace, record_to_delete.pid)
 
@@ -158,7 +158,7 @@ def delete_patientrecord(
         DeletePIDResponseSchema:  Summary of database items deleted
     """
     if not record_to_delete.pid:
-        raise ValueError("Target PatientRecord does not have a PID")
+        raise ValueError("Target PatientRecord does not have a PID")  # pragma: no cover
 
     empi_to_delete = _find_empi_items_to_delete(jtrace, record_to_delete.pid)
 

--- a/ukrdc_fastapi/query/delete.py
+++ b/ukrdc_fastapi/query/delete.py
@@ -2,6 +2,7 @@ import hashlib
 from dataclasses import dataclass
 
 from fastapi.exceptions import HTTPException
+from sqlalchemy import select
 from sqlalchemy.orm.session import Session
 from ukrdc_sqla.empi import LinkRecord, MasterRecord, Person, PidXRef, WorkItem
 from ukrdc_sqla.ukrdc import PatientRecord
@@ -41,21 +42,20 @@ def _find_empi_items_to_delete(jtrace: Session, pid: str) -> EMPIDeleteItems:
     to_delete = EMPIDeleteItems(
         persons=[], master_records=[], pidxrefs=[], work_items=[], link_records=[]
     )
-    to_delete.pidxrefs = jtrace.query(PidXRef).filter(PidXRef.pid == pid).all()
-    to_delete.persons = jtrace.query(Person).filter(Person.localid == pid).all()
+
+    to_delete.pidxrefs = jtrace.scalars(select(PidXRef).where(PidXRef.pid == pid)).all()
+    to_delete.persons = jtrace.scalars(
+        select(Person).where(Person.localid == pid)
+    ).all()
 
     for person_record in to_delete.persons:
         # Find work items related to person
-        to_delete.work_items.extend(
-            jtrace.query(WorkItem).filter(WorkItem.person_id == person_record.id).all()
-        )
+        stmt = select(WorkItem).where(WorkItem.person_id == person_record.id)
+        to_delete.work_items.extend(jtrace.scalars(stmt).all())
 
         # Find link records related to person
-        link_records_related_to_person = (
-            jtrace.query(LinkRecord)
-            .filter(LinkRecord.person_id == person_record.id)
-            .all()
-        )
+        stmt = select(LinkRecord).where(LinkRecord.person_id == person_record.id)
+        link_records_related_to_person = jtrace.scalars(stmt).all()
         to_delete.link_records.extend(link_records_related_to_person)
 
         # Find master IDs directly related to Person
@@ -64,30 +64,24 @@ def _find_empi_items_to_delete(jtrace: Session, pid: str) -> EMPIDeleteItems:
         ]
 
         for master_id in master_ids:
-            # Find link records related to the Master Record but NOT the Person
-            # currently being deleted
-            link_records_related_to_other_persons = (
-                jtrace.query(LinkRecord)
-                .filter(
-                    LinkRecord.master_id == master_id,
-                    LinkRecord.person_id != person_record.id,
-                )
-                .all()
+            # Find link records related to the Master Record but NOT the Person currently being deleted
+            stmt = select(LinkRecord).where(
+                LinkRecord.master_id == master_id,
+                LinkRecord.person_id != person_record.id,
             )
+            link_records_related_to_other_persons = jtrace.scalars(stmt).all()
 
-            # If the above query comes back empty, the Master Record is ONLY
-            # linked to the Person being deleted, and so can itself be deleted
+            # If the above query comes back empty, the Master Record is ONLY linked to the Person being deleted, and so can itself be deleted
             if not link_records_related_to_other_persons:
-                master_record = jtrace.query(MasterRecord).get(master_id)
+                master_record = jtrace.get(MasterRecord, master_id)
                 if master_record:
                     # Add the Master Record to be deleted
                     to_delete.master_records.append(master_record)
                     # Find work items related to master record
-                    to_delete.work_items.extend(
-                        jtrace.query(WorkItem)
-                        .filter(WorkItem.master_id == master_record.id)
-                        .all()
+                    stmt = select(WorkItem).where(
+                        WorkItem.master_id == master_record.id
                     )
+                    to_delete.work_items.extend(jtrace.scalars(stmt).all())
 
     open_work_items: list[WorkItem] = [
         work_item for work_item in to_delete.work_items if work_item.status == 1

--- a/ukrdc_fastapi/query/facilities/__init__.py
+++ b/ukrdc_fastapi/query/facilities/__init__.py
@@ -275,7 +275,7 @@ def get_facilities(
     # Look for a pre-calculated cache of the facilities list (see `ukrdc_fastapi.tasks.repeated`)
     cache = BasicCache(redis, CacheKey.FACILITIES_LIST)
     if not cache.exists:
-        stmt = select(Facility).filter(Facility.code.notin_(ABSTRACT_FACILITIES))
+        stmt = select(Facility).where(Facility.code.notin_(ABSTRACT_FACILITIES))
         cache.set(
             build_facilities_list(stmt, ukrdc3, errorsdb),
             expire=settings.cache_facilities_list_seconds,

--- a/ukrdc_fastapi/query/facilities/__init__.py
+++ b/ukrdc_fastapi/query/facilities/__init__.py
@@ -1,10 +1,9 @@
 from typing import Optional
 
 from redis import Redis
-from sqlalchemy import select
-from sqlalchemy.sql.selectable import Select
-from sqlalchemy import func
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
+from sqlalchemy.sql.selectable import Select
 from ukrdc_sqla.errorsdb import Latest, Message
 from ukrdc_sqla.ukrdc import Code, Facility, PatientRecord
 

--- a/ukrdc_fastapi/query/facilities/__init__.py
+++ b/ukrdc_fastapi/query/facilities/__init__.py
@@ -1,14 +1,16 @@
 from typing import Optional
 
 from redis import Redis
+from sqlalchemy import select
+from sqlalchemy.sql.selectable import Select
 from sqlalchemy import func
 from sqlalchemy.orm import Session
-from sqlalchemy.orm.query import Query
 from ukrdc_sqla.errorsdb import Latest, Message
 from ukrdc_sqla.ukrdc import Code, Facility, PatientRecord
 
 from ukrdc_fastapi.config import settings
 from ukrdc_fastapi.exceptions import MissingFacilityError
+from ukrdc_fastapi.query.utils import count_rows
 from ukrdc_fastapi.schemas.facility import (
     FacilityDataFlowSchema,
     FacilityDetailsSchema,
@@ -35,30 +37,37 @@ def get_facility(
     Returns:
         FacilityDetailsSchema: Matched facility
     """
-    facility = ukrdc3.query(Facility).filter(Facility.code == facility_code).first()
+    stmt = select(Facility).where(Facility.code == facility_code)
+    facility = ukrdc3.scalars(stmt).first()
 
     if not facility:
         raise MissingFacilityError(facility_code)
 
     # Get facility messages
-    messages = (
-        errorsdb.query(Latest)
+    stmt_messages = (
+        select(Latest)
         .join(Message)
-        .filter(Latest.facility == facility.code)
+        .where(Latest.facility == facility.code)
         .order_by(Message.received.desc())
     )
+    messages = errorsdb.scalars(stmt_messages)
 
     latest_message = messages.first()
-    patients_receiving_messages = messages.count()
-    patients_receiving_errors = messages.filter(Message.msg_status == "ERROR").count()
-
-    total_records = (
-        ukrdc3.query(PatientRecord)
-        .filter(PatientRecord.sendingfacility == facility_code)
-        .filter(PatientRecord.sendingextract.notin_(["PVMIG", "HSMIG"]))
-        .count()
+    patients_receiving_messages = count_rows(stmt_messages, errorsdb)
+    patients_receiving_errors = count_rows(
+        stmt_messages.where(Message.msg_status == "ERROR"), errorsdb
     )
 
+    # Get total number of records for this facility
+    stmt_total_records = (
+        select(PatientRecord)
+        .where(PatientRecord.sendingfacility == facility_code)
+        .where(PatientRecord.sendingextract.notin_(["PVMIG", "HSMIG"]))
+    )
+
+    total_records = count_rows(stmt_total_records, ukrdc3)
+
+    # Build statistics
     statistics = FacilityStatisticsSchema(
         total_patients=total_records,
         patients_receiving_messages=patients_receiving_messages,
@@ -99,18 +108,19 @@ def get_facility_extracts(
     Returns:
         FacilityExtractsSchema: Extract counts
     """
-    facility = ukrdc3.query(Facility).filter(Facility.code == facility_code).first()
+    stmt = select(Facility).where(Facility.code == facility_code)
+    facility = ukrdc3.scalars(stmt).first()
 
     if not facility:
         raise MissingFacilityError(facility_code)
 
-    query = (
-        ukrdc3.query(PatientRecord.sendingextract, func.count("*"))
-        .filter(PatientRecord.sendingfacility == facility_code)
+    stmt_query = (
+        select(PatientRecord.sendingextract, func.count("*"))
+        .where(PatientRecord.sendingfacility == facility_code)
         .group_by(PatientRecord.sendingextract)
     )
 
-    extracts = dict(query.all())
+    extracts = dict(ukrdc3.execute(stmt_query).all())
 
     return FacilityExtractsSchema(
         ukrdc=extracts.get("UKRDC", 0),
@@ -127,7 +137,7 @@ def get_facility_extracts(
 
 
 def build_facilities_list(
-    facilities_query: Query, ukrdc3: Session, errorsdb: Session
+    facilities_stmt: Select, ukrdc3: Session, errorsdb: Session
 ) -> list[FacilityDetailsSchema]:
     """Build a list of FacilityDetailsSchema objects from a facilities query.
 
@@ -141,63 +151,69 @@ def build_facilities_list(
     """
 
     # Execute statement to retreive available facilities list for this user
-    available_facilities = facilities_query.all()
+    available_facilities = ukrdc3.scalars(facilities_stmt).all()
 
     # Pre-fetch descriptions for all facilities available to the user
     # We want to avoid using facility.description as this is an associationproxy,
     # meaning that a new query is generated for each access, in this case for each
     # facility in the list. We speed this up by orders of magnitude by fetching ALL
     # descriptions in one query.
-    descriptions = {
-        code.code: code.description
-        for code in ukrdc3.query(Code)
-        .filter(Code.coding_standard == "RR1+")
-        .filter(Code.code.in_([facility.code for facility in available_facilities]))
-    }
+    stmt_facility_codes = (
+        select(Code)
+        .where(Code.coding_standard == "RR1+")
+        .where(Code.code.in_([facility.code for facility in available_facilities]))
+    )
+    facility_codes = ukrdc3.scalars(stmt_facility_codes).all()
+    descriptions = {code.code: code.description for code in facility_codes}
 
     # Build statistics
-    total_records_q = (
-        ukrdc3.query(PatientRecord.sendingfacility, func.count("*"))
-        .filter(PatientRecord.sendingextract.notin_(["PVMIG", "HSMIG"]))
-        .filter(
+    stmt_total_records = (
+        select(PatientRecord.sendingfacility, func.count("*"))
+        .where(PatientRecord.sendingextract.notin_(["PVMIG", "HSMIG"]))
+        .where(
             PatientRecord.sendingfacility.in_(
                 [facility.code for facility in available_facilities]
             )
         )
         .group_by(PatientRecord.sendingfacility)
     )
-    total_records_dict = {row[0].upper(): row[1] for row in total_records_q}
+
+    total_records = ukrdc3.execute(stmt_total_records).all()
+    total_records_dict = {row[0].upper(): row[1] for row in total_records}
 
     # Get a count of each facility-status combination from latest messages
     # We can use these counts to build up all "current status" statistics,
     # e.g. number of patients most recently receiving error messages
-    status_counts_query = (
-        errorsdb.query(
-            Latest.facility, Message.msg_status, func.count(Message.msg_status)
-        )
+    stmt_status_counts = (
+        select(Latest.facility, Message.msg_status, func.count(Message.msg_status))
         .join(Message)
-        .filter(
+        .where(
             Latest.facility.in_([facility.code for facility in available_facilities])
         )
         .group_by(Latest.facility, Message.msg_status)
     )
+
+    status_counts = errorsdb.execute(stmt_status_counts).all()
+
     # Create an empty dict to store facility status counts
     status_counts_dict: dict[str, dict[str, int]] = {}
     # Iterate over each row in the query result
-    for row in status_counts_query:
+    for row in status_counts:
         # Set dict[facility][status] = count
         status_counts_dict.setdefault(row[0].upper(), {})[row[1]] = row[2]
 
     # Get the most recent message received time for each facility
-    most_recent_q = (
-        errorsdb.query(Latest.facility, func.max(Message.received))
+    stmt_most_recent = (
+        select(Latest.facility, func.max(Message.received))
         .join(Message)
-        .filter(
+        .where(
             Latest.facility.in_([facility.code for facility in available_facilities])
         )
         .group_by(Latest.facility)
     )
-    most_recent_dict = {row[0].upper(): row[1] for row in most_recent_q}
+
+    most_recent = errorsdb.execute(stmt_most_recent).all()
+    most_recent_dict = {row[0].upper(): row[1] for row in most_recent}
 
     # Build list of facility details
     facility_list: list[FacilityDetailsSchema] = []
@@ -259,14 +275,9 @@ def get_facilities(
     # Look for a pre-calculated cache of the facilities list (see `ukrdc_fastapi.tasks.repeated`)
     cache = BasicCache(redis, CacheKey.FACILITIES_LIST)
     if not cache.exists:
+        stmt = select(Facility).filter(Facility.code.notin_(ABSTRACT_FACILITIES))
         cache.set(
-            build_facilities_list(
-                ukrdc3.query(Facility).filter(
-                    Facility.code.notin_(ABSTRACT_FACILITIES)
-                ),
-                ukrdc3,
-                errorsdb,
-            ),
+            build_facilities_list(stmt, ukrdc3, errorsdb),
             expire=settings.cache_facilities_list_seconds,
         )
 

--- a/ukrdc_fastapi/query/facilities/__init__.py
+++ b/ukrdc_fastapi/query/facilities/__init__.py
@@ -114,13 +114,17 @@ def get_facility_extracts(
     if not facility:
         raise MissingFacilityError(facility_code)
 
-    stmt_query = (
+    stmt_extract_counts = (
         select(PatientRecord.sendingextract, func.count("*"))
         .where(PatientRecord.sendingfacility == facility_code)
         .group_by(PatientRecord.sendingextract)
     )
 
-    extracts = dict(ukrdc3.execute(stmt_query).all())
+    extract_counts = ukrdc3.execute(stmt_extract_counts).all()
+
+    extracts: dict[str, int] = {
+        row[0]: row[1] for row in extract_counts if row[0] is not None
+    }
 
     return FacilityExtractsSchema(
         ukrdc=extracts.get("UKRDC", 0),

--- a/ukrdc_fastapi/query/facilities/errors.py
+++ b/ukrdc_fastapi/query/facilities/errors.py
@@ -1,5 +1,6 @@
 import datetime
 from typing import Optional
+from sqlalchemy import select
 
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.query import Query
@@ -12,9 +13,8 @@ from ukrdc_fastapi.schemas.common import HistoryPoint
 from ukrdc_fastapi.utils import daterange
 
 
-def get_patients_latest_errors(
+def query_patients_latest_errors(
     ukrdc3: Session,
-    errorsdb: Session,
     facility_code: str,
     channels: Optional[list[str]] = None,
 ) -> Query:
@@ -28,23 +28,24 @@ def get_patients_latest_errors(
     Returns:
         Query: SQLAlchemy query
     """
-    facility = ukrdc3.query(Facility).filter(Facility.code == facility_code).first()
+    stmt = select(Facility).where(Facility.code == facility_code)
+    facility = ukrdc3.scalars(stmt).first()
 
     if not facility:
         raise MissingFacilityError(facility_code)
 
-    query = (
-        errorsdb.query(Message)
+    stmt_errors = (
+        select(Message)
         .join(Latest)
-        .filter(Latest.facility == facility.code)
-        .filter(Message.msg_status == "ERROR")
+        .where(Latest.facility == facility.code)
+        .where(Message.msg_status == "ERROR")
     )
 
     # Optionally filter by channels
     if channels is not None:
-        query = query.filter(Message.channel_id.in_(channels))
+        stmt_errors = stmt_errors.where(Message.channel_id.in_(channels))
 
-    return query
+    return stmt_errors
 
 
 def get_errors_history(
@@ -67,11 +68,12 @@ def get_errors_history(
     Returns:
         list[HistoryPoint]: Time-series error data
     """
-    code = (
-        ukrdc3.query(Code)
-        .filter(Code.coding_standard == "RR1+", Code.code == facility_code)
-        .first()
+    stmt_code = (
+        select(Code)
+        .where(Code.coding_standard == "RR1+")
+        .where(Code.code == facility_code)
     )
+    code = ukrdc3.scalars(stmt_code).first()
 
     if not code:
         raise MissingFacilityError(facility_code)
@@ -83,12 +85,13 @@ def get_errors_history(
     range_until: datetime.date = until or datetime.date.today()
 
     # Get history within range
-    history = (
-        statsdb.query(ErrorHistory)
-        .filter(ErrorHistory.facility == facility_code)
-        .filter(ErrorHistory.date >= range_since)
-        .filter(ErrorHistory.date <= range_until)
+    stmt_history = (
+        select(ErrorHistory)
+        .where(ErrorHistory.facility == facility_code)
+        .where(ErrorHistory.date >= range_since)
+        .where(ErrorHistory.date <= range_until)
     )
+    history = statsdb.scalars(stmt_history).all()
 
     # Create an initially empty full history dictionary
     full_history: dict[datetime.date, int] = {

--- a/ukrdc_fastapi/query/facilities/errors.py
+++ b/ukrdc_fastapi/query/facilities/errors.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import Optional
-from sqlalchemy import select
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.selectable import Select
 from ukrdc_sqla.errorsdb import Latest, Message

--- a/ukrdc_fastapi/query/facilities/errors.py
+++ b/ukrdc_fastapi/query/facilities/errors.py
@@ -3,7 +3,7 @@ from typing import Optional
 from sqlalchemy import select
 
 from sqlalchemy.orm import Session
-from sqlalchemy.orm.query import Query
+from sqlalchemy.sql.selectable import Select
 from ukrdc_sqla.errorsdb import Latest, Message
 from ukrdc_sqla.stats import ErrorHistory
 from ukrdc_sqla.ukrdc import Code, Facility
@@ -17,7 +17,7 @@ def query_patients_latest_errors(
     ukrdc3: Session,
     facility_code: str,
     channels: Optional[list[str]] = None,
-) -> Query:
+) -> Select:
     """Retrieve the most recent error messages for each patient currently receiving errors.
 
     Args:

--- a/ukrdc_fastapi/query/facilities/reports.py
+++ b/ukrdc_fastapi/query/facilities/reports.py
@@ -55,11 +55,13 @@ def select_facility_report_cc001(
         select(PatientRecord.ukrdcid)
         .join(q_no_treatment, PatientRecord.ukrdcid == q_no_treatment.c.ukrdcid)
         .join(ProgramMembership, ProgramMembership.pid == PatientRecord.pid)
-    ).subquery()
+    )
 
     # Return all the rows in q_no_treatment that do NOT appear in q_has_memberships
-    q_no_treatment_and_no_memberships = select(q_no_treatment).where(
-        q_no_treatment.c.ukrdcid.notin_(q_no_treatment_but_has_memberships)
+    q_no_treatment_and_no_memberships = (
+        select(q_no_treatment)
+        .where(q_no_treatment.c.ukrdcid.notin_(q_no_treatment_but_has_memberships))
+        .subquery()
     )
 
     # Return PatientRecord ORM objects from q_no_treatment_and_no_memberships
@@ -96,7 +98,7 @@ def select_facility_report_pm001(
         .join(ProgramMembership, ProgramMembership.pid == PatientRecord.pid)
         .where(ProgramMembership.program_name == "PKB")
         .where(ProgramMembership.totime == None)  # noqa: E711 # No end time
-    ).subquery()
+    )
 
     return (
         select(PatientRecord)

--- a/ukrdc_fastapi/query/facilities/reports.py
+++ b/ukrdc_fastapi/query/facilities/reports.py
@@ -1,17 +1,18 @@
 import datetime
 
 from dateutil.relativedelta import relativedelta
-from sqlalchemy import or_
-from sqlalchemy.orm import Query, Session
+from sqlalchemy import or_, select
+from sqlalchemy.sql.selectable import Select
+from sqlalchemy.orm import Session
 from ukrdc_sqla.ukrdc import Facility, Patient, PatientRecord, ProgramMembership
 
 from ukrdc_fastapi.exceptions import MissingFacilityError
 
 
-def get_facility_report_cc001(
+def select_facility_report_cc001(
     ukrdc3: Session,
     facility_code: str,
-) -> Query:
+) -> Select:
     """
     Custom Cohort Report 001:
         No treatment or programme membership to explain presence in UKRDC.
@@ -22,10 +23,11 @@ def get_facility_report_cc001(
         facility_code (str): Facility/unit code
 
     Returns:
-        Query: Query of patients mathching the report conditions
+        Select: Select of patients mathching the report conditions
     """
     # Assert the facility exists
-    facility = ukrdc3.query(Facility).filter(Facility.code == facility_code).first()
+    stmt = select(Facility).where(Facility.code == facility_code)
+    facility = ukrdc3.scalars(stmt).first()
 
     if not facility:
         raise MissingFacilityError(facility_code)
@@ -35,43 +37,41 @@ def get_facility_report_cc001(
 
     # Find all records in the facility with no treatment, matching the DoD condition
     q_no_treatment = (
-        ukrdc3.query(PatientRecord)
+        select(PatientRecord)
         .join(Patient)
-        .filter(PatientRecord.sendingfacility == facility.code)
-        .filter(PatientRecord.sendingextract == "UKRDC")
-        .filter(PatientRecord.treatments == None)  # noqa: E711 # No treatments
-        .filter(
+        .where(PatientRecord.sendingfacility == facility.code)
+        .where(PatientRecord.sendingextract == "UKRDC")
+        .where(PatientRecord.treatments == None)  # noqa: E711 # No treatments
+        .where(
             or_(
                 Patient.deathtime == None,  # noqa: E711
                 Patient.deathtime >= dod_cutoff,
             )
         )
-    )
-
-    # Create a subquery for all records in the facility with no treatment
-    q_ukrdcids_to_check = q_no_treatment.subquery()
+    ).subquery()
 
     # Find all the rows in q_no_treatment with a UKRDCID that has memberships attached to it
     q_no_treatment_but_has_memberships = (
-        ukrdc3.query(PatientRecord.ukrdcid)
-        .join(
-            q_ukrdcids_to_check, PatientRecord.ukrdcid == q_ukrdcids_to_check.c.ukrdcid
-        )
+        select(PatientRecord.ukrdcid)
+        .join(q_no_treatment, PatientRecord.ukrdcid == q_no_treatment.c.ukrdcid)
         .join(ProgramMembership, ProgramMembership.pid == PatientRecord.pid)
-    )
+    ).subquery()
 
     # Return all the rows in q_no_treatment that do NOT appear in q_has_memberships
-    q_no_treatment_and_no_memberships = q_no_treatment.filter(
-        PatientRecord.ukrdcid.notin_(q_no_treatment_but_has_memberships)
+    q_no_treatment_and_no_memberships = select(q_no_treatment).where(
+        q_no_treatment.c.ukrdcid.notin_(q_no_treatment_but_has_memberships)
     )
 
-    return q_no_treatment_and_no_memberships
+    # Return PatientRecord ORM objects from q_no_treatment_and_no_memberships
+    return select(PatientRecord).where(
+        PatientRecord.ukrdcid.in_(select(q_no_treatment_and_no_memberships.c.ukrdcid))
+    )
 
 
-def get_facility_report_pm001(
+def select_facility_report_pm001(
     ukrdc3: Session,
     facility_code: str,
-) -> Query:
+) -> Select:
     """
     Program Membership Report 001:
         Patients with no *active* PKB membership record
@@ -81,27 +81,26 @@ def get_facility_report_pm001(
         facility_code (str): Facility/unit code
 
     Returns:
-        Query: Query of patients mathching the report conditions
+        Select: Select of patients mathching the report conditions
     """
     # Assert the facility exists
-    facility = ukrdc3.query(Facility).filter(Facility.code == facility_code).first()
+    stmt = select(Facility).where(Facility.code == facility_code)
+    facility = ukrdc3.execute(stmt).scalar_one()
 
     if not facility:
         raise MissingFacilityError(facility_code)
 
     # All UKRDC IDs with active PKB program memberships
     q2 = (
-        ukrdc3.query(PatientRecord.ukrdcid)
+        select(PatientRecord.ukrdcid)
         .join(ProgramMembership, ProgramMembership.pid == PatientRecord.pid)
-        .filter(ProgramMembership.program_name == "PKB")
-        .filter(ProgramMembership.totime == None)  # noqa: E711 # No end time
-    )
+        .where(ProgramMembership.program_name == "PKB")
+        .where(ProgramMembership.totime == None)  # noqa: E711 # No end time
+    ).subquery()
 
-    q = (
-        ukrdc3.query(PatientRecord)
-        .filter(PatientRecord.sendingfacility == facility.code)
-        .filter(PatientRecord.sendingextract == "UKRDC")
-        .filter(PatientRecord.ukrdcid.notin_(q2))  # No related program memberships
+    return (
+        select(PatientRecord)
+        .where(PatientRecord.sendingfacility == facility.code)
+        .where(PatientRecord.sendingextract == "UKRDC")
+        .where(PatientRecord.ukrdcid.notin_(q2))  # No related program memberships
     )
-
-    return q

--- a/ukrdc_fastapi/query/facilities/reports.py
+++ b/ukrdc_fastapi/query/facilities/reports.py
@@ -2,8 +2,8 @@ import datetime
 
 from dateutil.relativedelta import relativedelta
 from sqlalchemy import or_, select
-from sqlalchemy.sql.selectable import Select
 from sqlalchemy.orm import Session
+from sqlalchemy.sql.selectable import Select
 from ukrdc_sqla.ukrdc import Facility, Patient, PatientRecord, ProgramMembership
 
 from ukrdc_fastapi.exceptions import MissingFacilityError

--- a/ukrdc_fastapi/query/facilities/stats.py
+++ b/ukrdc_fastapi/query/facilities/stats.py
@@ -1,5 +1,6 @@
 import datetime
 from typing import Optional
+from sqlalchemy import select
 
 from sqlalchemy.orm import Session
 from ukrdc_sqla.ukrdc import Facility
@@ -29,7 +30,8 @@ def get_facility_demographic_stats(
         FacilityDemographicStats: Facility demographic distribution statistics
     """
     # Assert the facility exists
-    facility = ukrdc3.query(Facility).filter(Facility.code == facility_code).first()
+    stmt = select(Facility).where(Facility.code == facility_code)
+    facility = ukrdc3.scalars(stmt).first()
 
     if not facility:
         raise MissingFacilityError(facility_code)
@@ -54,7 +56,8 @@ def get_facility_dialysis_stats(
         DialysisStats: Facility demographic distribution statistics
     """
     # Assert the facility exists
-    facility = ukrdc3.query(Facility).filter(Facility.code == facility_code).first()
+    stmt = select(Facility).where(Facility.code == facility_code)
+    facility = ukrdc3.scalars(stmt).first()
 
     if not facility:
         raise MissingFacilityError(facility_code)

--- a/ukrdc_fastapi/query/facilities/stats.py
+++ b/ukrdc_fastapi/query/facilities/stats.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import Optional
-from sqlalchemy import select
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 from ukrdc_sqla.ukrdc import Facility
 from ukrdc_stats.calculators.demographics import (

--- a/ukrdc_fastapi/query/masterrecords.py
+++ b/ukrdc_fastapi/query/masterrecords.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
 from sqlalchemy import select
-from sqlalchemy.sql.selectable import Select
 from sqlalchemy.orm import Session
+from sqlalchemy.sql.selectable import Select
 from ukrdc_sqla.empi import MasterRecord, Person
 from ukrdc_sqla.utils.links import (
     PersonMasterLink,

--- a/ukrdc_fastapi/query/masterrecords.py
+++ b/ukrdc_fastapi/query/masterrecords.py
@@ -29,7 +29,9 @@ def select_masterrecords_related_to_masterrecord(
         Query: SQLAlchemy query
     """
     # Find all related master record IDs by recursing through link records
-    related_master_ids, _ = find_related_ids(jtrace, {record.id}, set())
+    related_master_ids, _ = find_related_ids(
+        jtrace, {record.id} if record.id else set(), set()
+    )
     # Return a select of the matched master records
     records = select(MasterRecord).where(MasterRecord.id.in_(related_master_ids))
 

--- a/ukrdc_fastapi/query/memberships.py
+++ b/ukrdc_fastapi/query/memberships.py
@@ -1,6 +1,6 @@
 from sqlalchemy import null, select
-from sqlalchemy.sql.selectable import Select
 from sqlalchemy.orm import Session
+from sqlalchemy.sql.selectable import Select
 from ukrdc_sqla.ukrdc import PatientRecord, ProgramMembership
 
 

--- a/ukrdc_fastapi/query/messages.py
+++ b/ukrdc_fastapi/query/messages.py
@@ -5,8 +5,8 @@ from mirth_client import MirthAPI
 from mirth_client.models import ConnectorMessageData, ConnectorMessageModel
 from pydantic import Field
 from sqlalchemy import select
-from sqlalchemy.sql.selectable import Select
 from sqlalchemy.orm.session import Session
+from sqlalchemy.sql.selectable import Select
 from ukrdc_sqla.empi import MasterRecord
 from ukrdc_sqla.errorsdb import Message
 from ukrdc_sqla.ukrdc import PatientRecord

--- a/ukrdc_fastapi/query/messages.py
+++ b/ukrdc_fastapi/query/messages.py
@@ -6,7 +6,6 @@ from mirth_client.models import ConnectorMessageData, ConnectorMessageModel
 from pydantic import Field
 from sqlalchemy import select
 from sqlalchemy.sql.selectable import Select
-from sqlalchemy.orm.query import Query
 from sqlalchemy.orm.session import Session
 from ukrdc_sqla.empi import MasterRecord
 from ukrdc_sqla.errorsdb import Message
@@ -173,11 +172,11 @@ def select_messages_related_to_patientrecord(
     channels: Optional[list[str]] = None,
     since: Optional[datetime.datetime] = None,
     until: Optional[datetime.datetime] = None,
-) -> Query:
+) -> Select:
     national_ids: list[str] = [
         number.patientid
         for number in record.patient.numbers
-        if number.numbertype == "NI"
+        if number.numbertype == "NI" and number.patientid is not None
     ]
 
     return select_messages(

--- a/ukrdc_fastapi/query/messages.py
+++ b/ukrdc_fastapi/query/messages.py
@@ -11,7 +11,9 @@ from ukrdc_sqla.errorsdb import Message
 from ukrdc_sqla.ukrdc import PatientRecord
 
 from ukrdc_fastapi.exceptions import ResourceNotFoundError
-from ukrdc_fastapi.query.masterrecords import get_masterrecords_related_to_masterrecord
+from ukrdc_fastapi.query.masterrecords import (
+    select_masterrecords_related_to_masterrecord,
+)
 from ukrdc_fastapi.schemas.base import OrmModel
 
 
@@ -148,10 +150,12 @@ def get_messages_related_to_masterrecord(
     Returns:
         Query: SQLAlchemy query
     """
-    related_master_records = get_masterrecords_related_to_masterrecord(record, jtrace)
+    related_master_records = jtrace.scalars(
+        select_masterrecords_related_to_masterrecord(record, jtrace)
+    )
 
     related_national_ids: list[str] = [
-        record.nationalid for record in related_master_records.all()
+        record.nationalid for record in related_master_records
     ]
 
     return get_messages(

--- a/ukrdc_fastapi/query/mirth/export.py
+++ b/ukrdc_fastapi/query/mirth/export.py
@@ -29,7 +29,7 @@ async def export_all_to_pv(
         )
 
     if not record.pid:
-        raise ValueError("PatientRecord has no PID")
+        raise ValueError("PatientRecord has no PID")  # pragma: no cover
 
     return await safe_send_mirth_message_to_name(
         "PV Outbound", build_export_all_message(record.pid), mirth, redis
@@ -49,7 +49,7 @@ async def export_tests_to_pv(
         )
 
     if not record.pid:
-        raise ValueError("PatientRecord has no PID")
+        raise ValueError("PatientRecord has no PID")  # pragma: no cover
 
     return await safe_send_mirth_message_to_name(
         "PV Outbound", build_export_tests_message(record.pid), mirth, redis
@@ -69,7 +69,7 @@ async def export_docs_to_pv(
         )
 
     if not record.pid:
-        raise ValueError("PatientRecord has no PID")
+        raise ValueError("PatientRecord has no PID")  # pragma: no cover
 
     return await safe_send_mirth_message_to_name(
         "PV Outbound", build_export_docs_message(record.pid), mirth, redis
@@ -88,7 +88,7 @@ async def export_all_to_radar(
         )
 
     if not record.pid:
-        raise ValueError("PatientRecord has no PID")
+        raise ValueError("PatientRecord has no PID")  # pragma: no cover
 
     return await safe_send_mirth_message_to_name(
         "RADAR Outbound", build_export_radar_message(record.pid), mirth, redis

--- a/ukrdc_fastapi/query/mirth/export.py
+++ b/ukrdc_fastapi/query/mirth/export.py
@@ -28,6 +28,9 @@ async def export_all_to_pv(
             f"Cannot export a {record.sendingfacility}/{record.sendingextract} record to PatientView"
         )
 
+    if not record.pid:
+        raise ValueError("PatientRecord has no PID")
+
     return await safe_send_mirth_message_to_name(
         "PV Outbound", build_export_all_message(record.pid), mirth, redis
     )
@@ -44,6 +47,9 @@ async def export_tests_to_pv(
         raise RecordTypeError(
             f"Cannot export a {record.sendingfacility}/{record.sendingextract} record to PatientView"
         )
+
+    if not record.pid:
+        raise ValueError("PatientRecord has no PID")
 
     return await safe_send_mirth_message_to_name(
         "PV Outbound", build_export_tests_message(record.pid), mirth, redis
@@ -62,6 +68,9 @@ async def export_docs_to_pv(
             f"Cannot export a {record.sendingfacility}/{record.sendingextract} record to PatientView"
         )
 
+    if not record.pid:
+        raise ValueError("PatientRecord has no PID")
+
     return await safe_send_mirth_message_to_name(
         "PV Outbound", build_export_docs_message(record.pid), mirth, redis
     )
@@ -77,6 +86,9 @@ async def export_all_to_radar(
         raise RecordTypeError(
             f"Cannot export a {record.sendingfacility}/{record.sendingextract} record to RADAR"
         )
+
+    if not record.pid:
+        raise ValueError("PatientRecord has no PID")
 
     return await safe_send_mirth_message_to_name(
         "RADAR Outbound", build_export_radar_message(record.pid), mirth, redis

--- a/ukrdc_fastapi/query/mirth/merge.py
+++ b/ukrdc_fastapi/query/mirth/merge.py
@@ -14,6 +14,12 @@ async def merge_master_records(
     redis: Redis,
 ) -> MirthMessageResponseSchema:
     """Merge a pair of MasterRecords"""
+    if not superseding.id:
+        raise ValueError("Superseding MasterRecord has no ID")
+
+    if not superseded.id:
+        raise ValueError("Superseded MasterRecord has no ID")
+
     return await safe_send_mirth_message_to_name(
         "Merge Patient",
         build_merge_message(superseding=superseding.id, superseded=superseded.id),

--- a/ukrdc_fastapi/query/mirth/merge.py
+++ b/ukrdc_fastapi/query/mirth/merge.py
@@ -15,10 +15,10 @@ async def merge_master_records(
 ) -> MirthMessageResponseSchema:
     """Merge a pair of MasterRecords"""
     if not superseding.id:
-        raise ValueError("Superseding MasterRecord has no ID")
+        raise ValueError("Superseding MasterRecord has no ID")  # pragma: no cover
 
     if not superseded.id:
-        raise ValueError("Superseded MasterRecord has no ID")
+        raise ValueError("Superseded MasterRecord has no ID")  # pragma: no cover
 
     return await safe_send_mirth_message_to_name(
         "Merge Patient",

--- a/ukrdc_fastapi/query/mirth/unlink.py
+++ b/ukrdc_fastapi/query/mirth/unlink.py
@@ -23,10 +23,10 @@ async def unlink_person_from_master_record(
 ) -> LinkRecordSchema:
     """Unlink a particular Person record from a Master Record"""
     if not master.id:
-        raise ValueError("Master Record has no ID")
+        raise ValueError("Master Record has no ID")  # pragma: no cover
 
     if not person.id:
-        raise ValueError("Person has no ID")
+        raise ValueError("Person has no ID")  # pragma: no cover
 
     # Build and send the unlink message
     await safe_send_mirth_message_to_name(

--- a/ukrdc_fastapi/query/mirth/unlink.py
+++ b/ukrdc_fastapi/query/mirth/unlink.py
@@ -22,7 +22,11 @@ async def unlink_person_from_master_record(
     redis: Redis,
 ) -> LinkRecordSchema:
     """Unlink a particular Person record from a Master Record"""
-    # Get records to assert user permission
+    if not master.id:
+        raise ValueError("Master Record has no ID")
+
+    if not person.id:
+        raise ValueError("Person has no ID")
 
     # Build and send the unlink message
     await safe_send_mirth_message_to_name(

--- a/ukrdc_fastapi/query/mirth/unlink.py
+++ b/ukrdc_fastapi/query/mirth/unlink.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from mirth_client.mirth import MirthAPI
 from redis import Redis
+from sqlalchemy import select
 from sqlalchemy.orm.session import Session
 from ukrdc_sqla.empi import LinkRecord, MasterRecord, Person
 
@@ -34,8 +35,7 @@ async def unlink_person_from_master_record(
     await sleep(0.5)  # Wait for the message to be processed (complete guess)
 
     # Find the new Master Record
-    first_link_related_to_person = (
-        jtrace.query(LinkRecord).filter(LinkRecord.person_id == person.id).first()
-    )
+    stmt = select(LinkRecord).where(LinkRecord.person_id == person.id)
+    first_link_related_to_person = jtrace.scalars(stmt).first()
 
     return LinkRecordSchema.from_orm(first_link_related_to_person)

--- a/ukrdc_fastapi/query/mirth/workitems.py
+++ b/ukrdc_fastapi/query/mirth/workitems.py
@@ -34,12 +34,12 @@ async def update_workitem(
         MirthMessageResponseSchema: Mirth API response object
     """
     if not workitem.id:
-        raise ValueError("WorkItem has no ID")
+        raise ValueError("WorkItem has no ID")  # pragma: no cover
 
     target_status: Optional[int] = status or workitem.status
 
     if not target_status:
-        raise ValueError("WorkItem status is not valid")
+        raise ValueError("WorkItem status is not valid")  # pragma: no cover
 
     return await safe_send_mirth_message_to_name(
         "WorkItemUpdate",
@@ -74,7 +74,7 @@ async def close_workitem(
         MirthMessageResponseSchema: Mirth API response object
     """
     if not workitem.id:
-        raise ValueError("WorkItem has no ID")
+        raise ValueError("WorkItem has no ID")  # pragma: no cover
 
     return await safe_send_mirth_message_to_name(
         "WorkItemUpdate",

--- a/ukrdc_fastapi/query/mirth/workitems.py
+++ b/ukrdc_fastapi/query/mirth/workitems.py
@@ -33,11 +33,19 @@ async def update_workitem(
     Returns:
         MirthMessageResponseSchema: Mirth API response object
     """
+    if not workitem.id:
+        raise ValueError("WorkItem has no ID")
+
+    target_status: Optional[int] = status or workitem.status
+
+    if not target_status:
+        raise ValueError("WorkItem status is not valid")
+
     return await safe_send_mirth_message_to_name(
         "WorkItemUpdate",
         build_update_workitem_message(
             workitem.id,
-            status or workitem.status,
+            target_status,
             comment or workitem.description,
             user_id,
         ),
@@ -65,6 +73,9 @@ async def close_workitem(
     Returns:
         MirthMessageResponseSchema: Mirth API response object
     """
+    if not workitem.id:
+        raise ValueError("WorkItem has no ID")
+
     return await safe_send_mirth_message_to_name(
         "WorkItemUpdate",
         build_close_workitem_message(workitem.id, comment or "", user_id),

--- a/ukrdc_fastapi/query/patientrecords/__init__.py
+++ b/ukrdc_fastapi/query/patientrecords/__init__.py
@@ -1,7 +1,7 @@
 from sqlalchemy import and_, select
-from sqlalchemy.sql.selectable import Select
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql import false as sql_false
+from sqlalchemy.sql.selectable import Select
 from ukrdc_sqla.empi import MasterRecord
 from ukrdc_sqla.errorsdb import Message
 from ukrdc_sqla.ukrdc import PatientNumber, PatientRecord

--- a/ukrdc_fastapi/query/patientrecords/__init__.py
+++ b/ukrdc_fastapi/query/patientrecords/__init__.py
@@ -1,72 +1,68 @@
-from sqlalchemy import and_
-from sqlalchemy.orm.query import Query
+from sqlalchemy import and_, select
+from sqlalchemy.sql.selectable import Select
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql import false as sql_false
 from ukrdc_sqla.empi import MasterRecord
 from ukrdc_sqla.errorsdb import Message
 from ukrdc_sqla.ukrdc import PatientNumber, PatientRecord
 
-from ukrdc_fastapi.query.masterrecords import get_masterrecords_related_to_masterrecord
+from ukrdc_fastapi.query.masterrecords import (
+    select_masterrecords_related_to_masterrecord,
+)
 
 
-def get_patientrecords_related_to_ukrdcid(ukrdcid: str, ukrdc3: Session) -> Query:
-    """Get a query of PatientRecords with a particular UKRDCID
+def select_patientrecords_related_to_ukrdcid(ukrdcid: str) -> Select:
+    """Get a select of PatientRecords with a particular UKRDCID
 
     Args:
         ukrdcid (str): UKRDC ID
-        ukrdc3 (Session): UKRDC SQLAlchemy session
 
     Returns:
-        Query: SQLAlchemy query
+        Select: SQLAlchemy select
     """
     # Return all records with a matching UKRDC ID that the user has permission to access
-    return ukrdc3.query(PatientRecord).filter(PatientRecord.ukrdcid == ukrdcid)
+    return select(PatientRecord).where(PatientRecord.ukrdcid == ukrdcid)
 
 
-def get_patientrecords_related_to_ni(ni: str, ukrdc3: Session) -> Query:
-    """Get a query of PatientRecords with a particular national identifier
+def select_patientrecords_related_to_ni(ni: str) -> Select:
+    """Get a select of PatientRecords with a particular national identifier
 
     Args:
         ni (str): National ID
-        ukrdc3 (Session): UKRDC SQLAlchemy session
 
     Returns:
-        Query: SQLAlchemy query
+        Select: SQLAlchemy select
     """
     # Return all records with a matching UKRDC ID that the user has permission to access
     return (
-        ukrdc3.query(PatientRecord)
+        select(PatientRecord)
         .join(PatientNumber, PatientNumber.pid == PatientRecord.pid)
-        .filter(and_(PatientNumber.numbertype == "NI", PatientNumber.patientid == ni))
+        .where(and_(PatientNumber.numbertype == "NI", PatientNumber.patientid == ni))
     )
 
 
-def get_patientrecords_related_to_message(
-    message_obj: Message, ukrdc3: Session
-) -> Query:
+def select_patientrecords_related_to_message(message_obj: Message) -> Select:
     """Get a query of PatientRecords related to a particular message
 
     Args:
         message_obj (Message): UKRDC Message object
-        ukrdc3 (Session): UKRDC SQLAlchemy session
 
     Returns:
-        Query: SQLAlchemy query
+        Select: SQLAlchemy select
     """
 
     # If no NI exists on the message, return an empty query with the correct type
     if not message_obj.ni:
-        return ukrdc3.query(PatientRecord).filter(sql_false())
+        return select(PatientRecord).where(sql_false())
 
-    records = get_patientrecords_related_to_ni(message_obj.ni, ukrdc3)
-    records = records.filter(PatientRecord.sendingfacility == message_obj.facility)
+    return select_patientrecords_related_to_ni(message_obj.ni).where(
+        PatientRecord.sendingfacility == message_obj.facility
+    )
 
-    return records
 
-
-def get_patientrecords_related_to_masterrecord(
-    record: MasterRecord, ukrdc3: Session, jtrace: Session
-) -> Query:
+def select_patientrecords_related_to_masterrecord(
+    record: MasterRecord, jtrace: Session
+) -> Select:
     """
     Get a list of patient records related to a Master Record.
 
@@ -84,14 +80,13 @@ def get_patientrecords_related_to_masterrecord(
     """
     # For the time being, it's possible for a patient to have multiple UKRDC IDs
     # Here, we get a list of all related UKRDC IDs from JTRACE
-    related_ukrdc_records = get_masterrecords_related_to_masterrecord(
-        record, jtrace
-    ).filter(MasterRecord.nationalid_type == "UKRDC")
+    stmt = select_masterrecords_related_to_masterrecord(record, jtrace).where(
+        MasterRecord.nationalid_type == "UKRDC"
+    )
+    related_records = jtrace.scalars(stmt).all()
 
     # Strip whitespace. Needed until we fix the issue with fixed-length nationalid column
-    related_ukrdcids = [record.nationalid.strip() for record in related_ukrdc_records]
+    related_ukrdcids = [record.nationalid.strip() for record in related_records]
 
     # Build queries for all records with matching UKRDC IDs
-    return ukrdc3.query(PatientRecord).filter(
-        PatientRecord.ukrdcid.in_(related_ukrdcids)
-    )
+    return select(PatientRecord).where(PatientRecord.ukrdcid.in_(related_ukrdcids))

--- a/ukrdc_fastapi/query/patientrecords/diagnoses.py
+++ b/ukrdc_fastapi/query/patientrecords/diagnoses.py
@@ -1,18 +1,20 @@
 from typing import Optional
+
 from pydantic import Field
 from sqlalchemy import and_, select
-from ukrdc_fastapi.schemas.patientrecord import (
-    DiagnosisSchema,
-    RenalDiagnosisSchema,
-    CauseOfDeathSchema,
-)
 from sqlalchemy.orm import Session
 from ukrdc_sqla.ukrdc import (
-    PatientRecord,
-    Diagnosis,
-    RenalDiagnosis,
     CauseOfDeath,
     Code,
+    Diagnosis,
+    PatientRecord,
+    RenalDiagnosis,
+)
+
+from ukrdc_fastapi.schemas.patientrecord import (
+    CauseOfDeathSchema,
+    DiagnosisSchema,
+    RenalDiagnosisSchema,
 )
 
 # Extended schemas which will include descriptions obtained by looking up codes in the code_list table

--- a/ukrdc_fastapi/query/persons.py
+++ b/ukrdc_fastapi/query/persons.py
@@ -1,10 +1,13 @@
+from sqlalchemy import select
 from sqlalchemy.orm import Session
-from sqlalchemy.orm.query import Query
+from sqlalchemy.sql.selectable import Select
 from ukrdc_sqla.empi import MasterRecord, Person
 from ukrdc_sqla.utils.links import find_related_ids
 
 
-def get_persons_related_to_masterrecord(record: MasterRecord, jtrace: Session) -> Query:
+def select_persons_related_to_masterrecord(
+    record: MasterRecord, jtrace: Session
+) -> Select:
     """Get a list of Person records related to a given Master Record
 
     Args:
@@ -12,7 +15,7 @@ def get_persons_related_to_masterrecord(record: MasterRecord, jtrace: Session) -
         record_id (int): Master Record ID
 
     Returns:
-        Query: SQLAlchemy query of Person records
+        Select: SQLAlchemy select of Person records
     """
     _, related_person_ids = find_related_ids(jtrace, {record.id}, set())
-    return jtrace.query(Person).filter(Person.id.in_(related_person_ids))
+    return select(Person).where(Person.id.in_(related_person_ids))

--- a/ukrdc_fastapi/query/persons.py
+++ b/ukrdc_fastapi/query/persons.py
@@ -17,5 +17,7 @@ def select_persons_related_to_masterrecord(
     Returns:
         Select: SQLAlchemy select of Person records
     """
-    _, related_person_ids = find_related_ids(jtrace, {record.id}, set())
+    _, related_person_ids = find_related_ids(
+        jtrace, {record.id} if record.id else set(), set()
+    )
     return select(Person).where(Person.id.in_(related_person_ids))

--- a/ukrdc_fastapi/query/users.py
+++ b/ukrdc_fastapi/query/users.py
@@ -1,4 +1,4 @@
-from sqlalchemy import exc
+from sqlalchemy import exc, select
 from sqlalchemy.orm.session import Session
 
 from ukrdc_fastapi.dependencies.auth import UKRDCUser
@@ -18,9 +18,8 @@ def get_user_preferences(usersdb: Session, user: UKRDCUser) -> UserPreferences:
     Returns:
         ReadUserPreferences: User preferences
     """
-    all_prefs = (
-        usersdb.query(UserPreference).filter(UserPreference.uid == user.id).all()
-    )
+    stmt = select(UserPreference).where(UserPreference.uid == user.id)
+    all_prefs = usersdb.scalars(stmt).all()
     raw_prefs_dict = {row.key: row.val for row in all_prefs}
     return UserPreferences(**raw_prefs_dict)
 

--- a/ukrdc_fastapi/query/utils.py
+++ b/ukrdc_fastapi/query/utils.py
@@ -1,0 +1,16 @@
+from sqlalchemy import select, func
+from sqlalchemy.orm.session import Session
+from sqlalchemy.sql.selectable import Select
+
+
+def count_rows(stmt: Select, session: Session) -> int:
+    # Create a subquery from the select statement
+    subquery = stmt.alias()
+
+    # Create a new select statement that selects the count of rows from the subquery
+    count_stmt = select(func.count()).select_from(subquery)
+
+    # Execute the count statement and fetch the count
+    count = session.execute(count_stmt).scalar_one()
+
+    return count

--- a/ukrdc_fastapi/query/utils.py
+++ b/ukrdc_fastapi/query/utils.py
@@ -8,9 +8,9 @@ def count_rows(stmt: Select, session: Session) -> int:
     subquery = stmt.alias()
 
     # Create a new select statement that selects the count of rows from the subquery
-    count_stmt = select(func.count()).select_from(subquery)
+    stmt_count = select(func.count()).select_from(subquery)
 
     # Execute the count statement and fetch the count
-    count = session.execute(count_stmt).scalar_one()
+    count = session.execute(stmt_count).scalar_one()
 
     return count

--- a/ukrdc_fastapi/query/utils.py
+++ b/ukrdc_fastapi/query/utils.py
@@ -1,4 +1,4 @@
-from sqlalchemy import select, func
+from sqlalchemy import func, select
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.selectable import Select
 

--- a/ukrdc_fastapi/query/workitems.py
+++ b/ukrdc_fastapi/query/workitems.py
@@ -1,8 +1,9 @@
 import datetime
 from typing import Optional
 
-from sqlalchemy.orm.query import Query
+from sqlalchemy import select
 from sqlalchemy.orm.session import Session
+from sqlalchemy.sql.selectable import Select
 from sqlalchemy.sql.expression import or_
 from sqlalchemy.sql.functions import func
 from ukrdc_sqla.empi import MasterRecord, Person, PidXRef, WorkItem
@@ -16,15 +17,14 @@ from ukrdc_fastapi.schemas.empi import WorkItemExtendedSchema
 from ukrdc_fastapi.utils import daterange
 
 
-def get_workitems(
-    jtrace: Session,
+def select_workitems(
     statuses: Optional[list[int]] = None,
     master_id: Optional[list[int]] = None,
     person_id: Optional[list[int]] = None,
     facility: Optional[str] = None,
     since: Optional[datetime.datetime] = None,
     until: Optional[datetime.datetime] = None,
-):
+) -> Select:
     """Get a list of WorkItems
 
     Args:
@@ -36,17 +36,17 @@ def get_workitems(
         until (Optional[datetime.datetime], optional): Show items until datetime. Defaults to None.
 
     Returns:
-        [type]: [description]
+        Select: SQLAlchemy query
     """
     status_list: list[int] = statuses or [1]
 
-    workitems = jtrace.query(WorkItem)
+    stmt = select(WorkItem)
 
     if facility:
-        workitems = (
-            workitems.outerjoin(Person)
+        stmt = (
+            stmt.outerjoin(Person)
             .outerjoin(PidXRef)
-            .filter(
+            .where(
                 or_(
                     PidXRef.sending_facility == facility,
                     WorkItem.attributes.like(f'%"SF":"{facility}"%'),
@@ -56,11 +56,11 @@ def get_workitems(
 
     # Optionally filter Workitems updated since
     if since:
-        workitems = workitems.filter(WorkItem.last_updated >= since)
+        stmt = stmt.where(WorkItem.last_updated >= since)
 
     # Optionally filter Workitems updated before
     if until:
-        workitems = workitems.filter(WorkItem.last_updated <= until)
+        stmt = stmt.where(WorkItem.last_updated <= until)
 
     filters = []
     if master_id:
@@ -69,10 +69,10 @@ def get_workitems(
         filters.append(WorkItem.person_id.in_(person_id))
 
     if master_id or person_id:
-        workitems = workitems.filter(or_(*filters))
+        stmt = stmt.where(or_(*filters))
 
     # Get a query of open workitems
-    return workitems.filter(WorkItem.status.in_(status_list))
+    return stmt.where(WorkItem.status.in_(status_list))
 
 
 def extend_workitem(workitem: WorkItem, jtrace: Session) -> WorkItemExtendedSchema:
@@ -123,7 +123,7 @@ def extend_workitem(workitem: WorkItem, jtrace: Session) -> WorkItemExtendedSche
     )
 
 
-def get_workitem_collection(workitem: WorkItem, jtrace: Session) -> Query:
+def select_workitem_collection(workitem: WorkItem, jtrace: Session) -> Select:
     """Get a list of WorkItems related via the LinkRecord network to a given WorkItem,
     raised by the same even as the given WorkItem.
 
@@ -132,14 +132,13 @@ def get_workitem_collection(workitem: WorkItem, jtrace: Session) -> Query:
         workitem_id (int): WorkItem ID
 
     Returns:
-        Query: SQLAlchemy query
+        Select: SQLAlchemy query
     """
-    related_workitems = get_workitems_related_to_workitem(workitem, jtrace)
+    stmt = select_workitems_related_to_workitem(workitem, jtrace)
+    return stmt.where(WorkItem.creation_date == workitem.creation_date)
 
-    return related_workitems.filter(WorkItem.creation_date == workitem.creation_date)
 
-
-def get_workitems_related_to_workitem(workitem: WorkItem, jtrace: Session) -> Query:
+def select_workitems_related_to_workitem(workitem: WorkItem, jtrace: Session) -> Select:
     """Get a list of WorkItems related via the LinkRecord network to a given WorkItem
 
     Args:
@@ -147,7 +146,7 @@ def get_workitems_related_to_workitem(workitem: WorkItem, jtrace: Session) -> Qu
         workitem_id (int): WorkItem ID
 
     Returns:
-        Query: SQLAlchemy query
+        Select: SQLAlchemy query
     """
     seen_master_ids: set[int] = set()
     seen_person_ids: set[int] = set()
@@ -161,16 +160,17 @@ def get_workitems_related_to_workitem(workitem: WorkItem, jtrace: Session) -> Qu
         jtrace, seen_master_ids, seen_person_ids
     )
 
-    other_workitems = jtrace.query(WorkItem).filter(
+    stmt = select(WorkItem).where(
         or_(
             WorkItem.master_id.in_(related_master_ids),
             WorkItem.person_id.in_(related_person_ids),
         )
     )
-    return other_workitems.filter(WorkItem.id != workitem.id)
+
+    return stmt.where(WorkItem.id != workitem.id)
 
 
-def get_workitems_related_to_message(message: Message, jtrace: Session) -> Query:
+def select_workitems_related_to_message(message: Message, jtrace: Session) -> Select:
     """Get a list of WorkItems related via the Patient Number to a given Message
 
     Args:
@@ -179,15 +179,16 @@ def get_workitems_related_to_message(message: Message, jtrace: Session) -> Query
         message_id (str): Message ID
 
     Returns:
-        Query: SQLAlchemy query
+        Select: SQLAlchemy query
     """
     # Get masterrecords directly referenced by the error
-    direct_records: list[MasterRecord] = (
-        jtrace.query(MasterRecord).filter(MasterRecord.nationalid == message.ni).all()
+    stmt = select(MasterRecord).where(
+        MasterRecord.nationalid == message.ni,
     )
+    direct_records: list[MasterRecord] = jtrace.scalars(stmt).all()
 
     # Get workitems related to masterrecords directly referenced by the error
-    return jtrace.query(WorkItem).filter(
+    return select(WorkItem).where(
         WorkItem.master_id.in_([record.id for record in direct_records]),
         WorkItem.status == 1,
     )
@@ -217,13 +218,14 @@ def get_full_workitem_history(
 
     # Get history within range
     trunc_func = func.date_trunc("day", WorkItem.creation_date)
-    history = (
-        jtrace.query(trunc_func, func.count(trunc_func))
-        .filter(trunc_func >= range_since)
-        .filter(trunc_func <= range_until)
+    history_stmt = (
+        select(trunc_func, func.count(trunc_func))
+        .where(trunc_func >= range_since)
+        .where(trunc_func <= range_until)
         .group_by(trunc_func)
         .order_by(trunc_func)
     )
+    history = jtrace.execute(history_stmt)
 
     # Create an initially empty full history dictionary
     full_history: dict[datetime.date, int] = {

--- a/ukrdc_fastapi/query/workitems.py
+++ b/ukrdc_fastapi/query/workitems.py
@@ -3,9 +3,9 @@ from typing import Optional
 
 from sqlalchemy import select
 from sqlalchemy.orm.session import Session
-from sqlalchemy.sql.selectable import Select
 from sqlalchemy.sql.expression import or_
 from sqlalchemy.sql.functions import func
+from sqlalchemy.sql.selectable import Select
 from ukrdc_sqla.empi import MasterRecord, Person, PidXRef, WorkItem
 from ukrdc_sqla.errorsdb import Message
 from ukrdc_sqla.utils.links import find_related_ids

--- a/ukrdc_fastapi/query/workitems.py
+++ b/ukrdc_fastapi/query/workitems.py
@@ -218,14 +218,14 @@ def get_full_workitem_history(
 
     # Get history within range
     trunc_func = func.date_trunc("day", WorkItem.creation_date)
-    history_stmt = (
+    stmt_history = (
         select(trunc_func, func.count(trunc_func))
         .where(trunc_func >= range_since)
         .where(trunc_func <= range_until)
         .group_by(trunc_func)
         .order_by(trunc_func)
     )
-    history = jtrace.execute(history_stmt)
+    history = jtrace.execute(stmt_history)
 
     # Create an initially empty full history dictionary
     full_history: dict[datetime.date, int] = {

--- a/ukrdc_fastapi/routers/api/admin/datahealth.py
+++ b/ukrdc_fastapi/routers/api/admin/datahealth.py
@@ -10,7 +10,7 @@ from ukrdc_sqla.stats import LastRunTimes
 from ukrdc_fastapi.dependencies import get_jtrace, get_statsdb
 from ukrdc_fastapi.dependencies.auth import Permissions, auth
 from ukrdc_fastapi.query.stats import MultipleUKRDCIDGroup, get_multiple_ukrdcids
-from ukrdc_fastapi.query.workitems import get_workitems
+from ukrdc_fastapi.query.workitems import select_workitems
 from ukrdc_fastapi.schemas.base import OrmModel
 from ukrdc_fastapi.schemas.empi import MasterRecordSchema
 from ukrdc_fastapi.utils.paginate import Page, paginate_sequence
@@ -83,7 +83,7 @@ def record_workitem_counts(
     Retreive a list of all master records with open work items, and the number of work items on each.
     Most useful when sorted by descending work item count, to identify records most in need of work item resolution.
     """
-    subq1 = get_workitems(jtrace, statuses=[1]).subquery()
+    subq1 = select_workitems(statuses=[1]).subquery()
 
     subq2 = (
         jtrace.query(subq1.c.masterid, func.count("*").label("workitem_count"))

--- a/ukrdc_fastapi/routers/api/admin/datahealth.py
+++ b/ukrdc_fastapi/routers/api/admin/datahealth.py
@@ -60,7 +60,7 @@ def datahealth_multiple_ukrdcids_last_run(
     statsdb: Session = Depends(get_statsdb),
 ):
     """Retreive the datetime the multiple_ukrdcid table was fully refreshed"""
-    return statsdb.query(LastRunTimes).get(("multiple_ukrdcid", ""))
+    return statsdb.get(LastRunTimes, ("multiple_ukrdcid", ""))
 
 
 @router.get(

--- a/ukrdc_fastapi/routers/api/codes.py
+++ b/ukrdc_fastapi/routers/api/codes.py
@@ -10,10 +10,10 @@ from ukrdc_fastapi.dependencies.auth import Permissions, auth
 from ukrdc_fastapi.query.codes import (
     ExtendedCodeSchema,
     get_code,
+    get_coding_standards,
     select_code_exclusions,
     select_code_maps,
     select_codes,
-    get_coding_standards,
 )
 from ukrdc_fastapi.schemas.code import CodeExclusionSchema, CodeMapSchema, CodeSchema
 from ukrdc_fastapi.utils.paginate import Page, paginate

--- a/ukrdc_fastapi/routers/api/empi.py
+++ b/ukrdc_fastapi/routers/api/empi.py
@@ -53,10 +53,8 @@ async def empi_merge(
 ):
     """Merge a pair of MasterRecords"""
     # Get the records
-    superseding: Optional[MasterRecord] = jtrace.query(MasterRecord).get(
-        args.superseding
-    )
-    superseded: Optional[MasterRecord] = jtrace.query(MasterRecord).get(args.superseded)
+    superseding: Optional[MasterRecord] = jtrace.get(MasterRecord, args.superseding)
+    superseded: Optional[MasterRecord] = jtrace.get(MasterRecord, args.superseded)
 
     if not (superseding and superseded):
         raise ResourceNotFoundError("Master Record not found")
@@ -84,8 +82,8 @@ async def empi_unlink(
 ):
     """Unlink a Person from a specified MasterRecord"""
     # Get the records
-    person = jtrace.query(Person).get(args.person_id)
-    master = jtrace.query(MasterRecord).get(args.master_id)
+    person = jtrace.get(Person, args.person_id)
+    master = jtrace.get(MasterRecord, args.master_id)
 
     if not person:
         raise ResourceNotFoundError("Person not found")

--- a/ukrdc_fastapi/routers/api/facilities/__init__.py
+++ b/ukrdc_fastapi/routers/api/facilities/__init__.py
@@ -29,7 +29,7 @@ from ukrdc_fastapi.query.facilities import (
 )
 from ukrdc_fastapi.query.facilities.errors import (
     get_errors_history,
-    get_patients_latest_errors,
+    query_patients_latest_errors,
 )
 from ukrdc_fastapi.schemas.common import HistoryPoint
 from ukrdc_fastapi.schemas.message import MessageSchema
@@ -121,7 +121,7 @@ def facility_patients_latest_errors(
     """Retreive time-series new error counts for the last year for a particular facility"""
     assert_facility_permission(code, user)
 
-    query = get_patients_latest_errors(ukrdc3, errorsdb, code, channels=channel)
+    stmt = query_patients_latest_errors(ukrdc3, code, channels=channel)
 
     audit.add_event(
         Resource.MESSAGES,
@@ -130,7 +130,7 @@ def facility_patients_latest_errors(
         parent=audit.add_event(Resource.FACILITY, code, AuditOperation.READ),
     )
 
-    return paginate(sorter.sort(query))
+    return paginate(errorsdb, sorter.sort(stmt))
 
 
 @router.get("/{code}/error_history", response_model=list[HistoryPoint])

--- a/ukrdc_fastapi/routers/api/facilities/reports.py
+++ b/ukrdc_fastapi/routers/api/facilities/reports.py
@@ -5,8 +5,8 @@ from ukrdc_fastapi.dependencies import get_ukrdc3
 from ukrdc_fastapi.dependencies.auth import Permissions, UKRDCUser, auth
 from ukrdc_fastapi.permissions.facilities import assert_facility_permission
 from ukrdc_fastapi.query.facilities.reports import (
-    get_facility_report_cc001,
-    get_facility_report_pm001,
+    select_facility_report_cc001,
+    select_facility_report_pm001,
 )
 from ukrdc_fastapi.schemas.patientrecord import PatientRecordSummarySchema
 from ukrdc_fastapi.utils.paginate import Page, paginate
@@ -36,7 +36,7 @@ def facility_reports_cc001(
     """
     assert_facility_permission(code, user)
 
-    return paginate(get_facility_report_cc001(ukrdc3, code))
+    return paginate(ukrdc3, select_facility_report_cc001(ukrdc3, code))
 
 
 # Program memberships
@@ -61,4 +61,4 @@ def facility_reports_pm001(
     """
     assert_facility_permission(code, user)
 
-    return paginate(get_facility_report_pm001(ukrdc3, code))
+    return paginate(ukrdc3, select_facility_report_pm001(ukrdc3, code))

--- a/ukrdc_fastapi/routers/api/masterrecords/dependencies.py
+++ b/ukrdc_fastapi/routers/api/masterrecords/dependencies.py
@@ -19,7 +19,7 @@ def _get_masterrecord(
 ) -> MasterRecord:
     """Simple dependency to turn ID query param and User object into a MasterRecord object."""
     # Get the record
-    record: Optional[MasterRecord] = jtrace.query(MasterRecord).get(record_id)
+    record: Optional[MasterRecord] = jtrace.get(MasterRecord, record_id)
     if not record:
         raise ResourceNotFoundError("Master Record not found")
 

--- a/ukrdc_fastapi/routers/api/masterrecords/record_id.py
+++ b/ukrdc_fastapi/routers/api/masterrecords/record_id.py
@@ -1,8 +1,9 @@
 import datetime
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Response, Security
+from fastapi import APIRouter, Depends
 from fastapi import Query as QueryParam
+from fastapi import Response, Security
 from pydantic import Field
 from sqlalchemy.orm import Session
 from starlette.status import HTTP_204_NO_CONTENT

--- a/ukrdc_fastapi/routers/api/patientrecords/__init__.py
+++ b/ukrdc_fastapi/routers/api/patientrecords/__init__.py
@@ -1,8 +1,9 @@
 import datetime
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Security
+from fastapi import APIRouter, Depends
 from fastapi import Query as QueryParam
+from fastapi import Security
 from fastapi.responses import Response
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -44,9 +45,7 @@ from ukrdc_fastapi.schemas.patientrecord import (
     DialysisSessionSchema,
     PatientRecordSchema,
 )
-from ukrdc_fastapi.schemas.patientrecord.laborder import (
-    ResultItemServiceSchema,
-)
+from ukrdc_fastapi.schemas.patientrecord.laborder import ResultItemServiceSchema
 from ukrdc_fastapi.schemas.patientrecord.medication import MedicationSchema
 from ukrdc_fastapi.schemas.patientrecord.observation import ObservationSchema
 from ukrdc_fastapi.schemas.patientrecord.procedure import TransplantSchema

--- a/ukrdc_fastapi/routers/api/patientrecords/__init__.py
+++ b/ukrdc_fastapi/routers/api/patientrecords/__init__.py
@@ -4,6 +4,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, Security
 from fastapi import Query as QueryParam
 from fastapi.responses import Response
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 from starlette.status import HTTP_204_NO_CONTENT
 from ukrdc_sqla.errorsdb import Message
@@ -259,6 +260,7 @@ def patient_delete(
 )
 def patient_medications(
     patient_record: PatientRecord = Depends(_get_patientrecord),
+    ukrdc3: Session = Depends(get_ukrdc3),
     sorter: SQLASorter = Depends(
         make_sqla_sorter(
             [Medication.fromtime, Medication.totime],
@@ -268,6 +270,8 @@ def patient_medications(
     audit: Auditer = Depends(get_auditer),
 ):
     """Retreive a specific patient's medications"""
+    stmt = select(Medication).where(Medication.pid == patient_record.pid)
+
     audit.add_event(
         Resource.MEDICATIONS,
         None,
@@ -276,7 +280,8 @@ def patient_medications(
             Resource.PATIENT_RECORD, patient_record.pid, AuditOperation.READ
         ),
     )
-    return sorter.sort(patient_record.medications).all()
+
+    return ukrdc3.scalars(sorter.sort(stmt)).all()
 
 
 # Treatments
@@ -289,6 +294,7 @@ def patient_medications(
 )
 def patient_treatments(
     patient_record: PatientRecord = Depends(_get_patientrecord),
+    ukrdc3: Session = Depends(get_ukrdc3),
     sorter: SQLASorter = Depends(
         make_sqla_sorter(
             [Treatment.fromtime, Treatment.totime],
@@ -298,6 +304,8 @@ def patient_treatments(
     audit: Auditer = Depends(get_auditer),
 ):
     """Retreive a specific patient's treatments"""
+    stmt = select(Treatment).where(Treatment.pid == patient_record.pid)
+
     audit.add_event(
         Resource.TREATMENTS,
         None,
@@ -306,7 +314,8 @@ def patient_treatments(
             Resource.PATIENT_RECORD, patient_record.pid, AuditOperation.READ
         ),
     )
-    return sorter.sort(patient_record.treatments).all()
+
+    return ukrdc3.scalars(sorter.sort(stmt)).all()
 
 
 @router.get(
@@ -316,6 +325,7 @@ def patient_treatments(
 )
 def patient_transplants(
     patient_record: PatientRecord = Depends(_get_patientrecord),
+    ukrdc3: Session = Depends(get_ukrdc3),
     sorter: SQLASorter = Depends(
         make_sqla_sorter(
             [Transplant.proceduretime, Transplant.creation_date],
@@ -325,6 +335,8 @@ def patient_transplants(
     audit: Auditer = Depends(get_auditer),
 ):
     """Retreive a specific patient's transplant procedures"""
+    stmt = select(Transplant).where(Transplant.pid == patient_record.pid)
+
     audit.add_event(
         Resource.TRANSPLANTS,
         None,
@@ -334,7 +346,7 @@ def patient_transplants(
         ),
     )
 
-    return sorter.sort(patient_record.transplants).all()
+    return ukrdc3.scalars(sorter.sort(stmt)).all()
 
 
 @router.get(
@@ -344,6 +356,7 @@ def patient_transplants(
 )
 def patient_surveys(
     patient_record: PatientRecord = Depends(_get_patientrecord),
+    ukrdc3: Session = Depends(get_ukrdc3),
     sorter: SQLASorter = Depends(
         make_sqla_sorter(
             [Survey.surveytime, Survey.updatedon],
@@ -353,6 +366,8 @@ def patient_surveys(
     audit: Auditer = Depends(get_auditer),
 ):
     """Retreive a specific patient's surveys"""
+    stmt = select(Survey).where(Survey.pid == patient_record.pid)
+
     audit.add_event(
         Resource.SURVEYS,
         None,
@@ -361,7 +376,8 @@ def patient_surveys(
             Resource.PATIENT_RECORD, patient_record.pid, AuditOperation.READ
         ),
     )
-    return sorter.sort(patient_record.surveys).all()
+
+    return ukrdc3.scalars(sorter.sort(stmt)).all()
 
 
 @router.get(
@@ -371,6 +387,7 @@ def patient_surveys(
 )
 def patient_observations(
     patient_record: PatientRecord = Depends(_get_patientrecord),
+    ukrdc3: Session = Depends(get_ukrdc3),
     code: Optional[list[str]] = QueryParam([]),
     sorter: SQLASorter = Depends(
         make_sqla_sorter(
@@ -381,9 +398,10 @@ def patient_observations(
     audit: Auditer = Depends(get_auditer),
 ):
     """Retreive a specific patient's lab orders"""
-    observations = patient_record.observations
+    stmt = select(Observation).where(Observation.pid == patient_record.pid)
+
     if code:
-        observations = observations.where(Observation.observation_code.in_(code))
+        stmt = stmt.where(Observation.observation_code.in_(code))
 
     audit.add_event(
         Resource.OBSERVATIONS,
@@ -394,7 +412,7 @@ def patient_observations(
         ),
     )
 
-    return paginate(sorter.sort(observations))
+    return paginate(ukrdc3, sorter.sort(stmt))
 
 
 @router.get(
@@ -404,6 +422,7 @@ def patient_observations(
 )
 def patient_dialysis_sessions(
     patient_record: PatientRecord = Depends(_get_patientrecord),
+    ukrdc3: Session = Depends(get_ukrdc3),
     sorter: SQLASorter = Depends(
         make_sqla_sorter(
             [DialysisSession.proceduretime, DialysisSession.creation_date],
@@ -413,7 +432,7 @@ def patient_dialysis_sessions(
     audit: Auditer = Depends(get_auditer),
 ):
     """Retreive a specific patient's lab orders"""
-    sessions = patient_record.dialysis_sessions
+    stmt = select(DialysisSession).where(DialysisSession.pid == patient_record.pid)
 
     audit.add_event(
         Resource.DIALYSISSESSIONS,
@@ -424,7 +443,7 @@ def patient_dialysis_sessions(
         ),
     )
 
-    return paginate(sorter.sort(sessions))
+    return paginate(ukrdc3, sorter.sort(stmt))
 
 
 # Available codes used to filter other resources
@@ -437,10 +456,15 @@ def patient_dialysis_sessions(
 )
 def patient_observation_codes(
     patient_record: PatientRecord = Depends(_get_patientrecord),
+    ukrdc3: Session = Depends(get_ukrdc3),
 ):
     """Retreive a list of observation codes available for a specific patient"""
-    codes = patient_record.observations.distinct(Observation.observation_code)
-    return {item.observation_code for item in codes.all()}
+    stmt = (
+        select(Observation.observation_code)
+        .where(Observation.pid == patient_record.pid)
+        .distinct()
+    )
+    return ukrdc3.scalars(stmt).all()
 
 
 @router.get(
@@ -450,9 +474,21 @@ def patient_observation_codes(
 )
 def patient_result_services(
     patient_record: PatientRecord = Depends(_get_patientrecord),
+    ukrdc3: Session = Depends(get_ukrdc3),
 ):
     """Retreive a list of resultitem services available for a specific patient"""
-    services = patient_record.result_items.distinct(ResultItem.service_id)
+    stmt = (
+        select(
+            ResultItem.service_id,
+            ResultItem.service_id_description,
+            ResultItem.service_id_std,
+        )
+        .where(ResultItem.pid == patient_record.pid)
+        .distinct(ResultItem.service_id)
+    )
+
+    services = ukrdc3.execute(stmt)
+
     return [
         ResultItemServiceSchema(
             id=item.service_id,

--- a/ukrdc_fastapi/routers/api/patientrecords/__init__.py
+++ b/ukrdc_fastapi/routers/api/patientrecords/__init__.py
@@ -15,6 +15,7 @@ from ukrdc_sqla.ukrdc import (
     Observation,
     PatientRecord,
     ResultItem,
+    LabOrder,
     Survey,
     Transplant,
     Treatment,
@@ -477,16 +478,13 @@ def patient_result_services(
 ):
     """Retreive a list of resultitem services available for a specific patient"""
     stmt = (
-        select(
-            ResultItem.service_id,
-            ResultItem.service_id_description,
-            ResultItem.service_id_std,
-        )
-        .where(ResultItem.pid == patient_record.pid)
+        select(ResultItem)
+        .join(LabOrder)
+        .where(LabOrder.pid == patient_record.pid)
         .distinct(ResultItem.service_id)
     )
 
-    services = ukrdc3.execute(stmt)
+    services = ukrdc3.scalars(stmt).all()
 
     return [
         ResultItemServiceSchema(
@@ -494,5 +492,5 @@ def patient_result_services(
             description=item.service_id_description,
             standard=item.service_id_std,
         )
-        for item in services.all()
+        for item in services
     ]

--- a/ukrdc_fastapi/routers/api/patientrecords/__init__.py
+++ b/ukrdc_fastapi/routers/api/patientrecords/__init__.py
@@ -30,7 +30,7 @@ from ukrdc_fastapi.permissions.messages import (
     apply_message_list_permissions,
     assert_message_permissions,
 )
-from ukrdc_fastapi.query.audit import get_auditevents_related_to_patientrecord
+from ukrdc_fastapi.query.audit import select_auditevents_related_to_patientrecord
 from ukrdc_fastapi.query.delete import (
     delete_patientrecord,
     summarise_delete_patientrecord,
@@ -110,16 +110,16 @@ def patient_audit(
     Retreive a page of audit events related to a particular master record.
     """
     page = paginate(
+        auditdb,
         sorter.sort(
-            get_auditevents_related_to_patientrecord(
+            select_auditevents_related_to_patientrecord(
                 patient_record,
-                auditdb,
                 resource=resource,
                 operation=operation,
                 since=since,
                 until=until,
             )
-        )
+        ),
     )
 
     for item in page.items:  # type: ignore

--- a/ukrdc_fastapi/routers/api/patientrecords/__init__.py
+++ b/ukrdc_fastapi/routers/api/patientrecords/__init__.py
@@ -35,7 +35,7 @@ from ukrdc_fastapi.query.delete import (
     delete_patientrecord,
     summarise_delete_patientrecord,
 )
-from ukrdc_fastapi.query.messages import get_messages_related_to_patientrecord
+from ukrdc_fastapi.query.messages import select_messages_related_to_patientrecord
 from ukrdc_fastapi.schemas.audit import AuditEventSchema
 from ukrdc_fastapi.schemas.delete import DeletePidRequest, DeletePIDResponseSchema
 from ukrdc_fastapi.schemas.message import MessageSchema, MinimalMessageSchema
@@ -148,7 +148,7 @@ def patient_messages(
     Retreive a list of messages related to a particular patient record.
     By default returns message created within the last 365 days.
     """
-    messages = get_messages_related_to_patientrecord(
+    messages = select_messages_related_to_patientrecord(
         patient_record,
         errorsdb,
         statuses=status,
@@ -189,7 +189,7 @@ def patient_record_latest_message(
 
     # Get messages related to the master record
     msgs = (
-        get_messages_related_to_patientrecord(
+        select_messages_related_to_patientrecord(
             patient_record,
             errorsdb,
             since=datetime.datetime.utcnow() - datetime.timedelta(days=365),

--- a/ukrdc_fastapi/routers/api/patientrecords/__init__.py
+++ b/ukrdc_fastapi/routers/api/patientrecords/__init__.py
@@ -194,8 +194,8 @@ def patient_record_latest_message(
             errorsdb,
             since=datetime.datetime.utcnow() - datetime.timedelta(days=365),
         )
-        .filter(Message.facility != "TRACING")
-        .filter(Message.filename.isnot(None))
+        .where(Message.facility != "TRACING")
+        .where(Message.filename.isnot(None))
     )
 
     # Apply permissions
@@ -386,7 +386,7 @@ def patient_observations(
     """Retreive a specific patient's lab orders"""
     observations = patient_record.observations
     if code:
-        observations = observations.filter(Observation.observation_code.in_(code))
+        observations = observations.where(Observation.observation_code.in_(code))
 
     audit.add_event(
         Resource.OBSERVATIONS,

--- a/ukrdc_fastapi/routers/api/patientrecords/dependencies.py
+++ b/ukrdc_fastapi/routers/api/patientrecords/dependencies.py
@@ -16,7 +16,7 @@ def _get_patientrecord(
     ukrdc3: Session = Depends(get_ukrdc3),
 ) -> PatientRecord:
     """Simple dependency to turn pid query param and User object into a PatientRecord object."""
-    record = ukrdc3.query(PatientRecord).get(pid)
+    record = ukrdc3.get(PatientRecord, pid)
 
     if not record:
         raise ResourceNotFoundError("Record not found")

--- a/ukrdc_fastapi/routers/api/patientrecords/diagnoses.py
+++ b/ukrdc_fastapi/routers/api/patientrecords/diagnoses.py
@@ -1,3 +1,4 @@
+from ukrdc_fastapi.dependencies import get_ukrdc3
 from ukrdc_fastapi.query.patientrecords.diagnoses import (
     ExtendedCauseOfDeathSchema,
     ExtendedDiagnosisSchema,
@@ -6,7 +7,7 @@ from ukrdc_fastapi.query.patientrecords.diagnoses import (
     get_patient_diagnosis,
     get_patient_renal_diagnosis,
 )
-
+from sqlalchemy.orm import Session
 from fastapi import APIRouter, Depends, Security
 from ukrdc_sqla.ukrdc import (
     PatientRecord,
@@ -33,6 +34,7 @@ router = APIRouter()
 )
 def patient_diagnosis(
     patient_record: PatientRecord = Depends(_get_patientrecord),
+    ukrdc3: Session = Depends(get_ukrdc3),
     audit: Auditer = Depends(get_auditer),
 ):
     """Retreive a specific patient's diagnoses"""
@@ -46,7 +48,7 @@ def patient_diagnosis(
         ),
     )
 
-    return get_patient_diagnosis(patient_record)
+    return get_patient_diagnosis(patient_record, ukrdc3)
 
 
 @router.get(
@@ -56,6 +58,7 @@ def patient_diagnosis(
 )
 def patient_renal_diagnosis(
     patient_record: PatientRecord = Depends(_get_patientrecord),
+    ukrdc3: Session = Depends(get_ukrdc3),
     audit: Auditer = Depends(get_auditer),
 ):
     """Retreive a specific patient's renal diagnoses"""
@@ -68,7 +71,7 @@ def patient_renal_diagnosis(
         ),
     )
 
-    return get_patient_renal_diagnosis(patient_record)
+    return get_patient_renal_diagnosis(patient_record, ukrdc3)
 
 
 @router.get(
@@ -78,6 +81,7 @@ def patient_renal_diagnosis(
 )
 def patient_cause_of_death(
     patient_record: PatientRecord = Depends(_get_patientrecord),
+    ukrdc3: Session = Depends(get_ukrdc3),
     audit: Auditer = Depends(get_auditer),
 ):
     """Retreive a specific patient's cause of death"""
@@ -91,4 +95,4 @@ def patient_cause_of_death(
         ),
     )
 
-    return get_patient_cause_of_death(patient_record)
+    return get_patient_cause_of_death(patient_record, ukrdc3)

--- a/ukrdc_fastapi/routers/api/patientrecords/diagnoses.py
+++ b/ukrdc_fastapi/routers/api/patientrecords/diagnoses.py
@@ -1,4 +1,15 @@
+from fastapi import APIRouter, Depends, Security
+from sqlalchemy.orm import Session
+from ukrdc_sqla.ukrdc import PatientRecord
+
 from ukrdc_fastapi.dependencies import get_ukrdc3
+from ukrdc_fastapi.dependencies.audit import (
+    Auditer,
+    AuditOperation,
+    Resource,
+    get_auditer,
+)
+from ukrdc_fastapi.dependencies.auth import Permissions, auth
 from ukrdc_fastapi.query.patientrecords.diagnoses import (
     ExtendedCauseOfDeathSchema,
     ExtendedDiagnosisSchema,
@@ -7,19 +18,7 @@ from ukrdc_fastapi.query.patientrecords.diagnoses import (
     get_patient_diagnosis,
     get_patient_renal_diagnosis,
 )
-from sqlalchemy.orm import Session
-from fastapi import APIRouter, Depends, Security
-from ukrdc_sqla.ukrdc import (
-    PatientRecord,
-)
 
-from ukrdc_fastapi.dependencies.audit import (
-    Auditer,
-    AuditOperation,
-    Resource,
-    get_auditer,
-)
-from ukrdc_fastapi.dependencies.auth import Permissions, auth
 from .dependencies import _get_patientrecord
 
 router = APIRouter()

--- a/ukrdc_fastapi/routers/api/patientrecords/documents.py
+++ b/ukrdc_fastapi/routers/api/patientrecords/documents.py
@@ -1,14 +1,10 @@
 from fastapi import APIRouter, Depends, HTTPException, Security
 from fastapi.responses import Response
 from sqlalchemy import select
-from sqlalchemy.orm import Session
-from sqlalchemy.orm import defer
-from ukrdc_sqla.ukrdc import (
-    Document,
-    PatientRecord,
-)
-from ukrdc_fastapi.dependencies import get_ukrdc3
+from sqlalchemy.orm import Session, defer
+from ukrdc_sqla.ukrdc import Document, PatientRecord
 
+from ukrdc_fastapi.dependencies import get_ukrdc3
 from ukrdc_fastapi.dependencies.audit import (
     Auditer,
     AuditOperation,

--- a/ukrdc_fastapi/routers/api/patientrecords/documents.py
+++ b/ukrdc_fastapi/routers/api/patientrecords/documents.py
@@ -74,7 +74,7 @@ def patient_document(
     audit: Auditer = Depends(get_auditer),
 ):
     """Retreive a specific patient's document information"""
-    stmt = select(Document).where(Document.pid == patient_record.pid)
+    stmt = select(Document).where(Document.id == document_id)
     document_obj = ukrdc3.execute(stmt).scalar_one_or_none()
 
     if not document_obj:
@@ -103,7 +103,7 @@ def patient_document_download(
     audit: Auditer = Depends(get_auditer),
 ):
     """Retreive a specific patient's document file"""
-    stmt = select(Document).where(Document.pid == patient_record.pid)
+    stmt = select(Document).where(Document.id == document_id)
     document_obj = ukrdc3.execute(stmt).scalar_one_or_none()
 
     if not document_obj:

--- a/ukrdc_fastapi/routers/api/patientrecords/documents.py
+++ b/ukrdc_fastapi/routers/api/patientrecords/documents.py
@@ -67,7 +67,7 @@ def patient_document(
     audit: Auditer = Depends(get_auditer),
 ):
     """Retreive a specific patient's document information"""
-    document_obj = patient_record.documents.filter(Document.id == document_id).first()
+    document_obj = patient_record.documents.where(Document.id == document_id).first()
     if not document_obj:
         raise HTTPException(404, detail="Document not found")
 
@@ -93,7 +93,7 @@ def patient_document_download(
     audit: Auditer = Depends(get_auditer),
 ):
     """Retreive a specific patient's document file"""
-    document_obj: Optional[Document] = patient_record.documents.filter(
+    document_obj: Optional[Document] = patient_record.documents.where(
         Document.id == document_id
     ).first()
     if not document_obj:

--- a/ukrdc_fastapi/routers/api/patientrecords/export.py
+++ b/ukrdc_fastapi/routers/api/patientrecords/export.py
@@ -4,11 +4,7 @@ from redis import Redis
 from sqlalchemy.orm import Session
 from ukrdc_sqla.ukrdc import PatientRecord
 
-from ukrdc_fastapi.dependencies import (
-    get_mirth,
-    get_redis,
-    get_ukrdc3,
-)
+from ukrdc_fastapi.dependencies import get_mirth, get_redis, get_ukrdc3
 from ukrdc_fastapi.dependencies.audit import (
     Auditer,
     AuditOperation,

--- a/ukrdc_fastapi/routers/api/patientrecords/laborders.py
+++ b/ukrdc_fastapi/routers/api/patientrecords/laborders.py
@@ -2,11 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Security
 from fastapi.responses import Response
 from sqlalchemy import select
 from sqlalchemy.orm import Session
-from ukrdc_sqla.ukrdc import (
-    LabOrder,
-    PatientRecord,
-    PVDelete,
-)
+from ukrdc_sqla.ukrdc import LabOrder, PatientRecord, PVDelete
 
 from ukrdc_fastapi.dependencies import get_ukrdc3
 from ukrdc_fastapi.dependencies.audit import (

--- a/ukrdc_fastapi/routers/api/patientrecords/laborders.py
+++ b/ukrdc_fastapi/routers/api/patientrecords/laborders.py
@@ -61,7 +61,7 @@ def patient_laborder(
     audit: Auditer = Depends(get_auditer),
 ) -> LabOrder:
     """Retreive a particular lab order"""
-    order = patient_record.lab_orders.filter(LabOrder.id == order_id).first()
+    order = patient_record.lab_orders.where(LabOrder.id == order_id).first()
     if not order:
         raise HTTPException(404, detail="Lab Order not found")
 
@@ -88,7 +88,7 @@ def patient_laborder_delete(
     audit: Auditer = Depends(get_auditer),
 ):
     """Mark a particular lab order for deletion"""
-    order = patient_record.lab_orders.filter(LabOrder.id == order_id).first()
+    order = patient_record.lab_orders.where(LabOrder.id == order_id).first()
     if not order:
         raise HTTPException(404, detail="Lab Order not found")
 

--- a/ukrdc_fastapi/routers/api/patientrecords/laborders.py
+++ b/ukrdc_fastapi/routers/api/patientrecords/laborders.py
@@ -62,6 +62,7 @@ def patient_laborder(
 ) -> LabOrder:
     """Retreive a particular lab order"""
     order = patient_record.lab_orders.where(LabOrder.id == order_id).first()
+
     if not order:
         raise HTTPException(404, detail="Lab Order not found")
 

--- a/ukrdc_fastapi/routers/api/patientrecords/results.py
+++ b/ukrdc_fastapi/routers/api/patientrecords/results.py
@@ -47,7 +47,7 @@ def patient_results(
     audit: Auditer = Depends(get_auditer),
 ):
     """Retreive a specific patient's lab orders"""
-    stmt = select(ResultItem).where(ResultItem.pid == patient_record.pid)
+    stmt = select(ResultItem).join(LabOrder).where(LabOrder.pid == patient_record.pid)
 
     if service_id:
         stmt = stmt.where(ResultItem.service_id.in_(service_id))

--- a/ukrdc_fastapi/routers/api/patientrecords/results.py
+++ b/ukrdc_fastapi/routers/api/patientrecords/results.py
@@ -1,16 +1,13 @@
 import datetime
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Security
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi import Query as QueryParam
+from fastapi import Security
 from fastapi.responses import Response
 from sqlalchemy import select
 from sqlalchemy.orm import Session
-from ukrdc_sqla.ukrdc import (
-    LabOrder,
-    PatientRecord,
-    ResultItem,
-)
+from ukrdc_sqla.ukrdc import LabOrder, PatientRecord, ResultItem
 
 from ukrdc_fastapi.dependencies import get_ukrdc3
 from ukrdc_fastapi.dependencies.audit import (
@@ -20,9 +17,7 @@ from ukrdc_fastapi.dependencies.audit import (
     get_auditer,
 )
 from ukrdc_fastapi.dependencies.auth import Permissions, auth
-from ukrdc_fastapi.schemas.patientrecord.laborder import (
-    ResultItemSchema,
-)
+from ukrdc_fastapi.schemas.patientrecord.laborder import ResultItemSchema
 from ukrdc_fastapi.utils.paginate import Page, paginate
 from ukrdc_fastapi.utils.sort import SQLASorter, make_sqla_sorter
 

--- a/ukrdc_fastapi/routers/api/patientrecords/results.py
+++ b/ukrdc_fastapi/routers/api/patientrecords/results.py
@@ -54,13 +54,13 @@ def patient_results(
     query = patient_record.result_items
 
     if service_id:
-        query = query.filter(ResultItem.service_id.in_(service_id))
+        query = query.where(ResultItem.service_id.in_(service_id))
     if order_id:
-        query = query.filter(ResultItem.order_id.in_(order_id))
+        query = query.where(ResultItem.order_id.in_(order_id))
     if since:
-        query = query.filter(ResultItem.observation_time >= since)
+        query = query.where(ResultItem.observation_time >= since)
     if until:
-        query = query.filter(ResultItem.observation_time <= until)
+        query = query.where(ResultItem.observation_time <= until)
 
     audit.add_event(
         Resource.RESULTITEMS,
@@ -85,7 +85,7 @@ def patient_result(
     audit: Auditer = Depends(get_auditer),
 ) -> ResultItem:
     """Retreive a particular lab result"""
-    item = patient_record.result_items.filter(ResultItem.id == resultitem_id).first()
+    item = patient_record.result_items.where(ResultItem.id == resultitem_id).first()
     if not item:
         raise HTTPException(404, detail="Result item not found")
 
@@ -112,7 +112,7 @@ def patient_result_delete(
     audit: Auditer = Depends(get_auditer),
 ):
     """Mark a particular lab result for deletion"""
-    item = patient_record.result_items.filter(ResultItem.id == resultitem_id).first()
+    item = patient_record.result_items.where(ResultItem.id == resultitem_id).first()
     if not item:
         raise HTTPException(404, detail="Result item not found")
 

--- a/ukrdc_fastapi/routers/api/ukrdcid/__init__.py
+++ b/ukrdc_fastapi/routers/api/ukrdcid/__init__.py
@@ -33,7 +33,7 @@ def ukrdcid_records(
     audit: Auditer = Depends(get_auditer),
 ):
     """Retreive patient records related to a specific patient record"""
-    stmt = select_patientrecords_related_to_ukrdcid(ukrdcid, ukrdc3)
+    stmt = select_patientrecords_related_to_ukrdcid(ukrdcid)
     stmt = apply_patientrecord_list_permission(stmt, user)
 
     related = ukrdc3.scalars(stmt).all()

--- a/ukrdc_fastapi/routers/api/ukrdcid/__init__.py
+++ b/ukrdc_fastapi/routers/api/ukrdcid/__init__.py
@@ -33,10 +33,10 @@ def ukrdcid_records(
     audit: Auditer = Depends(get_auditer),
 ):
     """Retreive patient records related to a specific patient record"""
-    related = select_patientrecords_related_to_ukrdcid(ukrdcid, ukrdc3)
+    stmt = select_patientrecords_related_to_ukrdcid(ukrdcid, ukrdc3)
+    stmt = apply_patientrecord_list_permission(stmt, user)
 
-    # Apply permissions
-    related = apply_patientrecord_list_permission(related, user)
+    related = ukrdc3.scalars(stmt).all()
 
     record_audit = audit.add_event(Resource.UKRDCID, ukrdcid, AuditOperation.READ)
     for record in related:
@@ -47,7 +47,7 @@ def ukrdcid_records(
             parent=record_audit,
         )
 
-    return related.all()
+    return related
 
 
 @router.post(

--- a/ukrdc_fastapi/routers/api/workitems/__init__.py
+++ b/ukrdc_fastapi/routers/api/workitems/__init__.py
@@ -10,7 +10,7 @@ from ukrdc_fastapi.dependencies import get_jtrace
 from ukrdc_fastapi.dependencies.audit import Auditer, get_auditer
 from ukrdc_fastapi.dependencies.auth import Permissions, UKRDCUser, auth
 from ukrdc_fastapi.permissions.workitems import apply_workitem_list_permission
-from ukrdc_fastapi.query.workitems import get_workitems
+from ukrdc_fastapi.query.workitems import select_workitems
 from ukrdc_fastapi.schemas.empi import WorkItemSchema
 from ukrdc_fastapi.utils.paginate import Page, paginate
 from ukrdc_fastapi.utils.sort import SQLASorter, make_sqla_sorter
@@ -53,15 +53,13 @@ def workitems(
     audit: Auditer = Depends(get_auditer),
 ):
     """Retreive a list of open work items from the EMPI"""
-    query = get_workitems(
-        jtrace, statuses=status or [], facility=facility, since=since, until=until
+    stmt = select_workitems(
+        statuses=status or [], facility=facility, since=since, until=until
     )
-
-    # Apply permissions
-    query = apply_workitem_list_permission(query, user)
+    stmt = apply_workitem_list_permission(stmt, user)
 
     # Paginate and sort
-    page = paginate(sorter.sort(query))
+    page = paginate(jtrace, sorter.sort(stmt))
 
     # Add audit events
     for item in page.items:  # type: ignore

--- a/ukrdc_fastapi/routers/api/workitems/workitem_id.py
+++ b/ukrdc_fastapi/routers/api/workitems/workitem_id.py
@@ -1,8 +1,9 @@
 import datetime
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Security
+from fastapi import APIRouter, Depends
 from fastapi import Query as QueryParam
+from fastapi import Security
 from mirth_client import MirthAPI
 from pydantic.fields import Field
 from redis import Redis

--- a/ukrdc_fastapi/routers/api/workitems/workitem_id.py
+++ b/ukrdc_fastapi/routers/api/workitems/workitem_id.py
@@ -164,16 +164,16 @@ def workitem_collection(
     audit: Auditer = Depends(get_auditer),
 ):
     """Retreive a list of other work items related to a particular work item"""
-    collection = select_workitem_collection(workitem_obj, jtrace)
+    stmt = select_workitem_collection(workitem_obj, jtrace)
+    stmt = apply_workitem_list_permission(stmt, user)
 
-    # Apply permissions
-    collection = apply_workitem_list_permission(collection, user)
+    collection = jtrace.scalars(stmt).all()
 
     # Add audit events
     for item in collection:
         audit.add_workitem(item)
 
-    return collection.all()
+    return collection
 
 
 @router.get(

--- a/ukrdc_fastapi/routers/api/workitems/workitem_id.py
+++ b/ukrdc_fastapi/routers/api/workitems/workitem_id.py
@@ -23,7 +23,7 @@ from ukrdc_fastapi.permissions.workitems import (
     apply_workitem_list_permission,
     assert_workitem_permission,
 )
-from ukrdc_fastapi.query.messages import get_messages
+from ukrdc_fastapi.query.messages import select_messages
 from ukrdc_fastapi.query.mirth.workitems import close_workitem, update_workitem
 from ukrdc_fastapi.query.workitems import (
     extend_workitem,
@@ -238,16 +238,13 @@ def workitem_messages(
     )
 
     # Get messages for NIs related to the work item
-    messages = get_messages(
-        errorsdb,
+    stmt = select_messages(
         statuses=status,
         nis=workitem_nis,
         facility=facility,
         since=since or worktiem_obj.creation_date - datetime.timedelta(hours=12),
         until=until or worktiem_obj.creation_date + datetime.timedelta(hours=12),
     )
+    stmt = apply_message_list_permissions(stmt, user)
 
-    # Apply permissions
-    messages = apply_message_list_permissions(messages, user)
-
-    return paginate(messages)
+    return paginate(errorsdb, stmt)

--- a/ukrdc_fastapi/schemas/audit.py
+++ b/ukrdc_fastapi/schemas/audit.py
@@ -52,7 +52,7 @@ class AuditEventSchema(OrmModel):
         """
         # For PatientRecord items
         if self.resource == Resource.PATIENT_RECORD.value and ukrdc3:
-            record = ukrdc3.query(PatientRecord).get(self.resource_id)
+            record = ukrdc3.get(PatientRecord, self.resource_id)
             if record:
                 # Obtain the first known MRN for the patient
                 first_mrn: Optional[PatientNumber] = None
@@ -79,7 +79,7 @@ class AuditEventSchema(OrmModel):
                         self.identifiers.append(first_mrn.patientid)
         # For MasterRecord items
         elif self.resource == Resource.MASTER_RECORD.value and jtrace:
-            master_record = jtrace.query(MasterRecord).get(self.resource_id)
+            master_record = jtrace.get(MasterRecord, self.resource_id)
             if master_record:
                 self.identifiers = [
                     f"{master_record.givenname} {master_record.surname}",

--- a/ukrdc_fastapi/schemas/audit.py
+++ b/ukrdc_fastapi/schemas/audit.py
@@ -84,8 +84,9 @@ class AuditEventSchema(OrmModel):
                 self.identifiers = [
                     f"{master_record.givenname} {master_record.surname}",
                     master_record.nationalid_type,
-                    master_record.nationalid.strip(),
                 ]
+                if master_record.nationalid:
+                    self.identifiers.append(master_record.nationalid.strip())
 
         # Recursively populate children
         if self.children:

--- a/ukrdc_fastapi/schemas/audit.py
+++ b/ukrdc_fastapi/schemas/audit.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from pydantic.fields import Field
 from sqlalchemy.orm.session import Session
 from ukrdc_sqla.empi import MasterRecord
-from ukrdc_sqla.ukrdc import PatientRecord, PatientNumber
+from ukrdc_sqla.ukrdc import PatientNumber, PatientRecord
 
 from ukrdc_fastapi.dependencies.audit import Resource
 

--- a/ukrdc_fastapi/schemas/patientrecord/__init__.py
+++ b/ukrdc_fastapi/schemas/patientrecord/__init__.py
@@ -2,6 +2,7 @@ import datetime
 from typing import Literal, Optional
 
 from pydantic import Field
+from sqlalchemy import select
 from sqlalchemy.orm.session import Session
 from ukrdc_sqla.empi import MasterRecord
 from ukrdc_sqla.ukrdc import PatientRecord
@@ -130,14 +131,13 @@ class PatientRecordSchema(PatientRecordSummarySchema):
         """
         record_dict = cls.from_orm(patient_record).dict()  # type: ignore  # mypy bug, see https://github.com/pydantic/pydantic/issues/5187
         if not record_dict.get("masterId"):
-            master_record = (
-                jtrace.query(MasterRecord)
-                .filter(
-                    MasterRecord.nationalid_type == "UKRDC",
-                    MasterRecord.nationalid == record_dict.get("ukrdcid"),
-                )
-                .first()
+            stmt_master_record = (
+                select(MasterRecord)
+                .where(MasterRecord.nationalid_type == "UKRDC")
+                .where(MasterRecord.nationalid == record_dict.get("ukrdcid"))
             )
+            master_record = jtrace.scalars(stmt_master_record).first()
+
             if master_record:
                 record_dict["masterId"] = master_record.id
         return cls(**record_dict)

--- a/ukrdc_fastapi/schemas/patientrecord/patientrecord.py
+++ b/ukrdc_fastapi/schemas/patientrecord/patientrecord.py
@@ -6,8 +6,8 @@ from sqlalchemy import select
 from sqlalchemy.orm.session import Session
 from ukrdc_sqla.empi import MasterRecord
 from ukrdc_sqla.ukrdc import PatientRecord
-from ukrdc_fastapi.schemas.base import OrmModel
 
+from ukrdc_fastapi.schemas.base import OrmModel
 from ukrdc_fastapi.schemas.patientrecord.laborder import ResultItemSchema
 from ukrdc_fastapi.schemas.patientrecord.medication import MedicationSchema
 from ukrdc_fastapi.schemas.patientrecord.observation import ObservationSchema

--- a/ukrdc_fastapi/tasks/repeated.py
+++ b/ukrdc_fastapi/tasks/repeated.py
@@ -1,6 +1,6 @@
 import logging
-from sqlalchemy import select
 
+from sqlalchemy import select
 from sqlalchemy.sql.functions import func
 from ukrdc_sqla.ukrdc import PatientRecord
 

--- a/ukrdc_fastapi/utils/__init__.py
+++ b/ukrdc_fastapi/utils/__init__.py
@@ -3,8 +3,6 @@ from contextlib import suppress
 from time import time
 from typing import Generator, Optional, Union
 
-from sqlalchemy.orm.query import Query
-
 
 class Timer:
     def __init__(self, description):
@@ -86,22 +84,3 @@ def daterange(
     # Add one day to end date to include it in the range
     for day_offset in range(int((end_date - start_date).days)):
         yield start_date + datetime.timedelta(day_offset)
-
-
-def query_union(queries: list[Query]) -> Query:
-    """Create an SQL UNION query from 1 or more queries
-
-    Args:
-        queries (list[Query]): List of queries
-
-    Raises:
-        ValueError: Union must include at least 1 query
-
-    Returns:
-        Query: Unionised query
-    """
-    if len(queries) < 1:
-        raise ValueError("Union must include at least 1 query")
-    if len(queries) < 2:
-        return queries[0]
-    return queries[0].union(*queries[1:])

--- a/ukrdc_fastapi/utils/cache.py
+++ b/ukrdc_fastapi/utils/cache.py
@@ -53,7 +53,7 @@ class FacilityCachePrefix(CachePrefix):
     KRT = "facilities:stats:krt"
 
 
-class TestCachePrefix(CachePrefix):
+class PytestCachePrefix(CachePrefix):
     """Key prefixes for internal test cache keys"""
 
     # For internal testing only

--- a/ukrdc_fastapi/utils/mirth/messages/pkb.py
+++ b/ukrdc_fastapi/utils/mirth/messages/pkb.py
@@ -190,7 +190,7 @@ def build_pkb_sync_messages(record: PatientRecord, ukrdc3: Session) -> list[str]
 
     # Check facility-level overrides
 
-    facility = ukrdc3.query(Facility).get(record.sendingfacility)
+    facility = ukrdc3.get(Facility, record.sendingfacility)
 
     if not facility:
         raise ResourceNotFoundError(record.sendingfacility or "None")

--- a/ukrdc_fastapi/utils/paginate.py
+++ b/ukrdc_fastapi/utils/paginate.py
@@ -5,10 +5,17 @@ from fastapi_pagination import paginate as paginate_sequence
 from fastapi_pagination.default import Page as BasePage
 from fastapi_pagination.default import Params as BaseParams
 from fastapi_pagination.ext.sqlalchemy import paginate, paginate_query
+from fastapi_pagination.utils import disable_installed_extensions_check
 
 __all__ = ["Page", "Params", "paginate", "paginate_sequence", "paginate_query"]
 
 T = TypeVar("T")  # pylint: disable=invalid-name
+
+# We sometimes paginate normal lists, not just SQLAlchemy queries,
+# so we need to disable the check that fastapi_pagination does
+# to warn you if you use the normal pagination function when you
+# have SQLAlchemy installed.
+disable_installed_extensions_check()
 
 
 class Params(BaseParams):

--- a/ukrdc_fastapi/utils/search.py
+++ b/ukrdc_fastapi/utils/search.py
@@ -223,9 +223,9 @@ def search_ukrdcids(  # pylint: disable=too-many-branches
     facility: list[str],
     search: list[str],
     ukrdc3: Session,
-) -> set[int]:
+) -> set[str]:
     """Search the UKRDC for a set of search items, and return a set of matching UKRDC IDs"""
-    match_sets: list[set[int]] = []
+    match_sets: list[set[str]] = []
 
     searchset = SearchSet()
 
@@ -248,33 +248,33 @@ def search_ukrdcids(  # pylint: disable=too-many-branches
 
     if searchset.ukrdc_numbers:
         query = records_from_ukrdcid(ukrdc3, searchset.ukrdc_numbers)
-        match_sets.append({record.ukrdcid for record in query})
+        match_sets.append({record.ukrdcid for record in query if record.ukrdcid})
 
     if searchset.mrn_numbers:
         query = records_from_mrn_no(ukrdc3, searchset.mrn_numbers)
-        match_sets.append({record.ukrdcid for record in query})
+        match_sets.append({record.ukrdcid for record in query if record.ukrdcid})
 
     if searchset.names:
         query = records_from_full_name(ukrdc3, searchset.names)
-        match_sets.append({record.ukrdcid for record in query})
+        match_sets.append({record.ukrdcid for record in query if record.ukrdcid})
 
     if searchset.dates:
         query = records_from_dob(ukrdc3, searchset.dates)
-        match_sets.append({record.ukrdcid for record in query})
+        match_sets.append({record.ukrdcid for record in query if record.ukrdcid})
 
     if searchset.pids:
         query = records_from_pid(ukrdc3, searchset.pids)
-        match_sets.append({record.ukrdcid for record in query})
+        match_sets.append({record.ukrdcid for record in query if record.ukrdcid})
 
     if searchset.facilities:
         query = records_from_facility(ukrdc3, searchset.facilities)
-        match_sets.append({record.ukrdcid for record in query})
+        match_sets.append({record.ukrdcid for record in query if record.ukrdcid})
 
-    non_empty_sets: list[set[int]] = [
+    non_empty_sets: list[set[str]] = [
         match_set for match_set in match_sets if match_set
     ]
 
-    matched_ids: set[int]
+    matched_ids: set[str]
     if non_empty_sets:
         matched_ids = set.intersection(*non_empty_sets)
     else:

--- a/ukrdc_fastapi/utils/search.py
+++ b/ukrdc_fastapi/utils/search.py
@@ -210,7 +210,7 @@ def records_from_dob(
     """Finds Ids from date of birth"""
     conditions = [Patient.birth_time == dob for dob in dobs]
     return ukrdc3.scalars(
-        select(PatientRecord).join(Patient).filter(or_(*conditions))
+        select(PatientRecord).join(Patient).where(or_(*conditions))
     ).all()
 
 

--- a/ukrdc_fastapi/utils/search.py
+++ b/ukrdc_fastapi/utils/search.py
@@ -1,8 +1,8 @@
 import datetime
 import re
 from typing import Iterable, Optional, Union
-from sqlalchemy import select
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.expression import or_
 from sqlalchemy.sql.functions import concat

--- a/ukrdc_fastapi/utils/sort.py
+++ b/ukrdc_fastapi/utils/sort.py
@@ -4,7 +4,8 @@ from typing import Any, Optional, Union
 
 from fastapi import HTTPException
 from sqlalchemy import Column
-from sqlalchemy.orm import Query as ORMQuery
+from sqlalchemy.orm import Query
+from sqlalchemy.sql.selectable import Select
 
 
 def rgetattr(obj, attr, *args):
@@ -41,7 +42,7 @@ class SQLASorter:
         self.default_sort_by = default_sort_by
         self.default_order_by = default_order_by
 
-    def sort(self, query: ORMQuery):
+    def sort(self, query: Union[Query, Select]):
         """Sort an SQLAlchemy query by the paremeters obtained from FastAPI
 
         Args:

--- a/ukrdc_fastapi/utils/sort.py
+++ b/ukrdc_fastapi/utils/sort.py
@@ -98,7 +98,7 @@ def make_sqla_sorter(
     Returns:
         [function]: FastAPI dependency function returning a SQLASorter instance
     """
-    column_map: dict[str, Column] = {col.key: col for col in columns}
+    column_map: dict[str, Column] = {col.key: col for col in columns if col.key}
     sort_enum = enum.Enum(  # type: ignore
         _make_sorter_enum_name(columns), {col.key: col.key for col in columns}
     )


### PR DESCRIPTION
In preparation for various SQLAlchemy deprecations, this PR drafts switching the UKRDC API to the new SQLAlchemy API.

See https://docs.sqlalchemy.org/en/14/changelog/migration_20.html#migration-orm-usage

## Todo

- [x] Finish replacing all `query()` API calls with `select()` API calls
  - [x] Main code
  - [x] Scripts
  - [x] Tests
- [x] Check for uses of `.query(` and `.filter(`
- [x] Make mypy happy
  - [x] Proper issues
  - [x] Issues with mypy treating ORM types as actual types (e.g. `"list[Document]" has no attribute "where"`). May be "more correct" to create fresh select statements for each query and filter by PID rather than using the ORM child attributes implicitly.
- [x] Clean up tests
- [x] Generally tidy round and improve consistency (e.g. use row counter utility function rather than ad-hoc implementations)
- [x] Test with frontend locally
