### PR TITLE
fix: dont report known safe exceptions to sentry

### DIFF
--- a/ukrdc_fastapi/dependencies/sentry.py
+++ b/ukrdc_fastapi/dependencies/sentry.py
@@ -9,6 +9,13 @@ from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 from sentry_sdk.integrations.starlette import StarletteIntegration
 
 from ukrdc_fastapi.config import configuration
+from ukrdc_fastapi.exceptions import (
+    NoActiveMembershipError,
+    PKBOutboundDisabledError,
+    PermissionsError,
+    RecordTypeError,
+    ResourceNotFoundError,
+)
 
 
 def add_sentry(app: FastAPI):
@@ -31,6 +38,13 @@ def add_sentry(app: FastAPI):
             environment=configuration.deployment_env,
             release=configuration.github_sha,
             profiles_sample_rate=1.0,
+            ignore_errors=[
+                PermissionsError,
+                ResourceNotFoundError,  # Ignore _all_ ResourceNotFoundError exceptions
+                NoActiveMembershipError,
+                PKBOutboundDisabledError,
+                RecordTypeError,
+            ],
         )
         app.add_middleware(SentryAsgiMiddleware)
     else:

--- a/ukrdc_fastapi/exceptions.py
+++ b/ukrdc_fastapi/exceptions.py
@@ -2,6 +2,8 @@ from typing import Any, Optional
 
 from fastapi.exceptions import HTTPException
 
+# Permissions
+
 
 class PermissionsError(HTTPException):
     def __init__(self, headers: Optional[dict[str, Any]] = None) -> None:
@@ -12,26 +14,7 @@ class PermissionsError(HTTPException):
         )
 
 
-class AmbigousQueryError(RuntimeError):
-    """
-    Raised when a query should return a single value but
-    multiple possible responses were found.
-    """
-
-
-class EmptyQueryError(RuntimeError):
-    """
-    Raised when a query should return a single value but
-    no possible responses were found.
-    """
-
-
-class MirthChannelError(RuntimeError):
-    """Error getting Mirth channel info"""
-
-
-class NoActiveMembershipError(RuntimeError):
-    """No active membership of the required type was found on this record"""
+# Resources
 
 
 class ResourceNotFoundError(RuntimeError):
@@ -52,17 +35,30 @@ class MissingCodeError(ResourceNotFoundError):
         super().__init__(f"Code {coding_standard}/{code} not found")
 
 
+# PKB
+
+
+class NoActiveMembershipError(RuntimeError):
+    """No active membership of the required type was found on this record"""
+
+
 class PKBOutboundDisabledError(RuntimeError):
     """PKB outbound sending disabled for this facility"""
 
 
+# Record types
+
+
 class RecordTypeError(RuntimeError):
-    """Record type not supported"""
+    """Operation cannot be performed on this record type"""
 
 
-class TaskLockError(Exception):
+# Background tasks
+
+
+class TaskLockError(RuntimeError):
     """Backbground task lock could not be acquired"""
 
 
-class TaskNotFoundError(Exception):
+class TaskNotFoundError(RuntimeError):
     """Requested background task does not exist"""


### PR DESCRIPTION
Ignores specific known exception types from being reported to Sentry, which we expect to be thrown from time to time by users. E.g. unable to sync PKB due to missing membership.