### PR TITLE
chore: Update base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-buster
+FROM python:3.11-slim-bookworm
 
 ARG GITHUB_SHA
 ARG GITHUB_REF


### PR DESCRIPTION
slim-buster is no longer supported, and it is causing issues when trying to build the image because it can't find the EOL repositories.

Couldn't think of anything that would prevent this but just in case I thought it best to raise a PR.