### PR TITLE
TNG-1217

### DIFF
--- a/ukrdc_fastapi/query/delete.py
+++ b/ukrdc_fastapi/query/delete.py
@@ -113,7 +113,10 @@ def _create_delete_patientrecord_summary(
         patient_record=record_to_delete_summary, empi=empi_to_delete_summary
     )
 
-    to_delete_json = to_delete_summary.json()
+    to_delete_json = to_delete_summary.json(
+        exclude_unset=True,
+        sort_keys=True
+    )
     # We ignore Bandit warnings here as MD5 is not being used for security purposes
     to_delete_hash = hashlib.md5(to_delete_json.encode()).hexdigest()  # nosec
 

--- a/ukrdc_fastapi/query/delete.py
+++ b/ukrdc_fastapi/query/delete.py
@@ -113,10 +113,7 @@ def _create_delete_patientrecord_summary(
         patient_record=record_to_delete_summary, empi=empi_to_delete_summary
     )
 
-    to_delete_json = to_delete_summary.json(
-        exclude_unset=True,
-        sort_keys=True
-    )
+    to_delete_json = to_delete_summary.json(exclude_unset=True, sort_keys=True)
     # We ignore Bandit warnings here as MD5 is not being used for security purposes
     to_delete_hash = hashlib.md5(to_delete_json.encode()).hexdigest()  # nosec
 


### PR DESCRIPTION
From my testing it seems that the issue originated from the orm queries, returning data with ought specific ordering, this would cause differences in the input for the hash function for records with multiple relationships, I have updated the empi orm query to order/sort the data by ids, However Patient Record is more dynamic and therefore I have added a function that will sort the pydantic version directly.