### PR TITLE
UK-39

### DIFF
--- a/ukrdc_fastapi/dependencies/database.py
+++ b/ukrdc_fastapi/dependencies/database.py
@@ -22,7 +22,8 @@ Ukrdc3Session = sessionmaker(
             settings.ukrdc_name,
         ),
         connect_args={"application_name": settings.application_name},
-        pool_pre_ping=True, # Test connection before using it, get a new one if stale
+        pool_pre_ping=True,  # Test connection before using it, get a new one if stale
+        pool_recycle=3600,  # If the connection is older than 1 hour, get a new one instead
     ),
 )
 
@@ -54,7 +55,8 @@ JtraceSession = sessionmaker(
             settings.jtrace_name,
         ),
         connect_args={"application_name": settings.application_name},
-        pool_pre_ping=True, # Test connection before using it, get a new one if stale
+        pool_pre_ping=True,  # Test connection before using it, get a new one if stale,
+        pool_recycle=3600,  # If the connection is older than 1 hour, get a new one instead
     ),
 )
 
@@ -86,7 +88,8 @@ ErrorsSession = sessionmaker(
             settings.errors_name,
         ),
         connect_args={"application_name": settings.application_name},
-        pool_pre_ping=True, # Test connection before using it, get a new one if stale
+        pool_pre_ping=True,  # Test connection before using it, get a new one if stale,
+        pool_recycle=3600,  # If the connection is older than 1 hour, get a new one instead
     ),
 )
 
@@ -118,7 +121,8 @@ StatsSession = sessionmaker(
             settings.stats_name,
         ),
         connect_args={"application_name": settings.application_name},
-        pool_pre_ping=True, # Test connection before using it, get a new one if stale
+        pool_pre_ping=True,  # Test connection before using it, get a new one if stale
+        pool_recycle=3600,  # If the connection is older than 1 hour, get a new one instead
     ),
 )
 
@@ -150,7 +154,8 @@ AuditSession = sessionmaker(
             settings.audit_name,
         ),
         connect_args={"application_name": settings.application_name},
-        pool_pre_ping=True, # Test connection before using it, get a new one if stale
+        pool_pre_ping=True,  # Test connection before using it, get a new one if stale
+        pool_recycle=3600,  # If the connection is older than 1 hour, get a new one instead
     ),
 )
 
@@ -175,7 +180,8 @@ UsersSession = sessionmaker(
             "sqlite", name=os.path.join(settings.sqlite_data_dir, settings.usersdb_name)
         ),
         connect_args={"check_same_thread": False},
-        pool_pre_ping=True, # Test connection before using it, get a new one if stale
+        pool_pre_ping=True,  # Test connection before using it, get a new one if stale
+        pool_recycle=3600,  # If the connection is older than 1 hour, get a new one instead
     )
 )
 

--- a/ukrdc_fastapi/dependencies/database.py
+++ b/ukrdc_fastapi/dependencies/database.py
@@ -22,6 +22,7 @@ Ukrdc3Session = sessionmaker(
             settings.ukrdc_name,
         ),
         connect_args={"application_name": settings.application_name},
+        pool_pre_ping=True, # Test connection before using it, get a new one if stale
     ),
 )
 
@@ -53,6 +54,7 @@ JtraceSession = sessionmaker(
             settings.jtrace_name,
         ),
         connect_args={"application_name": settings.application_name},
+        pool_pre_ping=True, # Test connection before using it, get a new one if stale
     ),
 )
 
@@ -84,6 +86,7 @@ ErrorsSession = sessionmaker(
             settings.errors_name,
         ),
         connect_args={"application_name": settings.application_name},
+        pool_pre_ping=True, # Test connection before using it, get a new one if stale
     ),
 )
 
@@ -115,6 +118,7 @@ StatsSession = sessionmaker(
             settings.stats_name,
         ),
         connect_args={"application_name": settings.application_name},
+        pool_pre_ping=True, # Test connection before using it, get a new one if stale
     ),
 )
 
@@ -146,6 +150,7 @@ AuditSession = sessionmaker(
             settings.audit_name,
         ),
         connect_args={"application_name": settings.application_name},
+        pool_pre_ping=True, # Test connection before using it, get a new one if stale
     ),
 )
 
@@ -170,6 +175,7 @@ UsersSession = sessionmaker(
             "sqlite", name=os.path.join(settings.sqlite_data_dir, settings.usersdb_name)
         ),
         connect_args={"check_same_thread": False},
+        pool_pre_ping=True, # Test connection before using it, get a new one if stale
     )
 )
 


### PR DESCRIPTION
Set `pool_pre_ping=True`
but also 
`pool_recycle=3600`, so that SQLA invalidates and gets a new connection after 1 hour.

Looking at the docs there might be some other helpful settings to help with the DB connections (like [`pool_use_lifo`](https://docs.sqlalchemy.org/en/21/core/engines.html#sqlalchemy.create_engine.params.pool_use_lifo)), but just `pool_pre_ping` should be fine for handling the disconnects.