### PR TITLE
fix(cache): fixed facility cache fix

### DIFF
--- a/ukrdc_fastapi/tasks/repeated.py
+++ b/ukrdc_fastapi/tasks/repeated.py
@@ -66,14 +66,15 @@ async def update_facilities_cache() -> None:
     """
 
     async def innerfunc():
-        await _run_in_threadpool(
-            get_facilities,
-            ukrdc3_session(),
-            errors_session(),
-            get_redis(),
-            True,  # include_inactive
-            True,  # include_empty
-        )
+        with ukrdc3_session() as ukrdc3, errors_session() as errors:
+            await _run_in_threadpool(
+                get_facilities,
+                ukrdc3,
+                errors,
+                get_redis(),
+                True,  # include_inactive
+                True,  # include_empty
+            )
 
     task = get_root_task_tracker().create(innerfunc, name="Update Facilities Cache")
     return await task.tracked()


### PR DESCRIPTION
on the server this error would appear `Failed Permanently Update Facilities Cache with error: '_GeneratorContextManager' object has no attribute 'scalars'` this has now been fixed `Finished Update Facilities Cache Successfully`