### PR TITLE
fix(logging): logging is now used on the repeated task rather than pr…

### DIFF
--- a/ukrdc_fastapi/utils/tasks.py
+++ b/ukrdc_fastapi/utils/tasks.py
@@ -1,5 +1,6 @@
 import datetime
 import inspect
+import logging
 from collections.abc import Callable
 from functools import wraps
 from typing import Any, Literal
@@ -18,6 +19,8 @@ _LOCK_PREFIX = "_LOCK_"
 
 VisibilityType = Literal["public", "private"]
 StatusType = Literal["pending", "running", "finished", "failed"]
+
+logger = logging.getLogger(__name__)
 
 
 class TrackableTaskSchema(JSONModel):
@@ -170,7 +173,9 @@ class TrackableTask:
             )
 
             # Update the task status to running
-            print(f"[{self.id}] Started {self.name} with arguments: {func_args_str}")
+            logger.info(
+                f"[{self.id}] Started {self.name} with arguments: {func_args_str}"
+            )
             self.status = "running"
             self.started = datetime.datetime.now()
             self._sync()
@@ -181,14 +186,16 @@ class TrackableTask:
 
             try:
                 await self._func(*args, **kwargs)
-                print(f"[{self.id}] Finished {self.name} Successfully")
+                logger.info(f"[{self.id}] Finished {self.name} Successfully")
                 # Mark the task as finished
                 self.status = "finished"
                 self._sync()
                 # Expire the task after the configured time
                 self.task_redis.expire(self._key, settings.redis_tasks_expire)
             except Exception as e:  # pylint: disable=broad-except
-                print(f"[{self.id}] Failed Permanently {self.name} with error: {e}")
+                logger.exception(
+                    f"[{self.id}] Failed Permanently {self.name} with error: {e}"
+                )
                 # Mark the task as errored
                 self.status = "failed"
                 # Set the error message

--- a/ukrdc_fastapi/utils/tasks.py
+++ b/ukrdc_fastapi/utils/tasks.py
@@ -192,9 +192,9 @@ class TrackableTask:
                 self._sync()
                 # Expire the task after the configured time
                 self.task_redis.expire(self._key, settings.redis_tasks_expire)
-            except Exception as e:  # pylint: disable=broad-except
+            except Exception as e:
                 logger.exception(
-                    f"[{self.id}] Failed Permanently {self.name} with error: {e}"
+                    f"[{self.id}] Failed Permanently {self.name} with error: {e}"  # noqa: TRY401
                 )
                 # Mark the task as errored
                 self.status = "failed"


### PR DESCRIPTION
logging is now used on the repeated task rather than printing which means the default formatting is now applied;
so we have gone from this ` fastapi_edge-1  | [xxx] Finished Update Facilities Cache Successfully ` to this ` ukrdc-fastapi  | 2026-08-10 15:43:06 [tasks(wrapper:189)] INFO: [xxx] Finished Update Facilities Cache Successfully `