### PR TITLE
chore(actions): improved actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,6 +179,14 @@ jobs:
       - name: Install Dependencies
         run: poetry install
 
+      - name: Set beta version from release tag
+        # Beta releases are tagged directly (e.g. 6.8.0-beta.1) rather than
+        # bumped in pyproject.toml, so pull the version from the tag itself.
+        # Only applies to `release` events - workflow_dispatch/push/PR runs
+        # keep whatever version is already in pyproject.toml.
+        if: github.event_name == 'release' && contains(github.event.release.tag_name, '-beta')
+        run: poetry version "${{ github.event.release.tag_name }}"
+
       - name: Generate API Spec
         run: poetry run python clients/generate_spec.py
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,6 +92,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Set up Python
+        if: github.event_name == 'release' && contains(github.event.release.tag_name, '-beta')
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install and configure Poetry
+        if: github.event_name == 'release' && contains(github.event.release.tag_name, '-beta')
+        run: python -m pip install -U pip && pip install poetry
+
+      - name: Set beta version from release tag
+        # Same rationale as the build-spec job: for a -beta release, use the
+        # tag itself as the version rather than requiring a manual bump
+        if: github.event_name == 'release' && contains(github.event.release.tag_name, '-beta')
+        run: poetry version "${{ github.event.release.tag_name }}"
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v6

--- a/README.md
+++ b/README.md
@@ -9,6 +9,20 @@
 - [OpenAPI Specification](https://renalreg.github.io/ukrdc-fastapi/openapi.json)
 - [`@ukkidney/ukrdc-axios-ts` Documentation](https://renalreg.github.io/ukrdc-fastapi/typescript-axios-client/)
 
+## Dev Notes
+
+### Beta releases
+
+Normal releases are handled by [release-please](https://github.com/googleapis/release-please) — merges to `main` are what bump the version in `pyproject.toml` and drive changelog generation. That version is the source of truth for the OpenAPI spec, docs, and Docker image on a standard release.
+
+If you want to test a branch's changes end-to-end (published spec, docs, Axios client, and a built Docker image) before you're confident it's ready to merge, you don't need to merge to `main` or bump `pyproject.toml` by hand. Instead, tag a release directly with `-beta` in the tag name, e.g.:
+
+    6.8.0-beta.1
+
+CI detects the `-beta` tag and uses it as the version for that build only — it overrides the Poetry version on the runner for the OpenAPI spec, Redoc docs, Axios client, and Docker image, but never commits anything back to the repo. `pyproject.toml` on `main` and release-please's own version tracking are unaffected, so there's nothing to revert afterwards.
+
+Beta tags can be created from any branch and don't require a merge to `main` first.
+
 ## Developer Installation
 
 ### Prerequisites


### PR DESCRIPTION
# Current Workflow
The current workflow for testing an uncertain batch of changes on a dev branch is to tag a -beta release rather than merging to main and cutting a full release. Doing that today means manually bumping the version in pyproject.toml, publishing, then reverting the bump afterwards — easy to forget, and it risks conflicting with release-please's own version tracking.

This removes the manual step: the beta tag drives the version for that CI run only, and release-please's bookkeeping in pyproject.toml/main is never touched.

# This PR
When a release is tagged with -beta in the tag name (e.g. 6.8.0-beta.1), CI now uses that tag as the version instead of whatever's committed in pyproject.toml:

build-spec job: overwrites the Poetry version before generating the OpenAPI spec, so it flows through to the spec itself, the Redoc docs, and the published Axios client.
publish job: same override, applied before the Docker build context is assembled, so the beta version is baked into the container image too (verified against the Dockerfile — COPY . ./ happens before poetry install, so single-source picks up the overridden version correctly).

In both cases the override is written with poetry version <tag> on the runner only — it's never committed back to the repo.



